### PR TITLE
Modularize alphabet to have different valid characters

### DIFF
--- a/Parameters.java
+++ b/Parameters.java
@@ -7,6 +7,21 @@ import java.io.*;
 
 public class Parameters {
 
+	public enum AlphabetType {
+		NUCLEOTIDES("AGTC"),
+		AMINO_ACIDS("ARNDBCEQZGHILKMFPSTWYV");
+
+		private final String validCharacters;
+
+		AlphabetType(String validCharacters) {
+			this. validCharacters = validCharacters;
+		}
+
+		public String getValidCharacters() {
+			return validCharacters;
+		}
+	}
+
 	// global parameters
 	public static double day = 0;
 	public static Virus urVirus = null;
@@ -76,7 +91,7 @@ public class Parameters {
 	public static boolean fixedStep = false;					// whether to fix mutation step size
 	public static String startingSequence = "AGTC";				// default starting sequence
 	public static String alphabetType = "nucleotides";          // default sequence to consist of nucleotides
-	public static String alphabet = "AGTC";                     // default valid letters to be nucleotides
+	public static String alphabet = AlphabetType.NUCLEOTIDES.getValidCharacters();                     // default valid letters to be nucleotides
 
 	// measured in years, starting at burnin
 	public static double getDate() {
@@ -261,7 +276,7 @@ public class Parameters {
 				alphabetType = (String) map.get("alphabetType");
 
 				if (alphabetType.equals("aminoAcids")) {
-					alphabet = "ARNDBCEQZGHILKMFPSTWYV";
+					alphabet = AlphabetType.AMINO_ACIDS.getValidCharacters();
 				}
 			}
 

--- a/Parameters.java
+++ b/Parameters.java
@@ -74,7 +74,9 @@ public class Parameters {
 	public static double sdStep = 0.3;
 	public static boolean mut2D = false;						// whether to mutate in a full 360 degree arc
 	public static boolean fixedStep = false;					// whether to fix mutation step size
-	public static String startingSequence = "AGTC";
+	public static String startingSequence = "AGTC";				// default starting sequence
+	public static String alphabetType = "nucleotides";          // default sequence to consist of nucleotides
+	public static String alphabet = "AGTC";                     // default valid letters to be nucleotides
 
 	// measured in years, starting at burnin
 	public static double getDate() {
@@ -252,11 +254,15 @@ public class Parameters {
 			if (map.get("fixedStep") != null) {
 				fixedStep = (boolean) map.get("fixedStep");
 			}
-			if (map.get("fixedStep") != null) {				
-				fixedStep = (boolean) map.get("fixedStep");	
-			}
 			if (map.get("startingSequence") != null) {
 				startingSequence = (String) map.get("startingSequence");
+			}
+			if (map.get("alphabetType") != null) {
+				alphabetType = (String) map.get("alphabetType");
+
+				if (alphabetType.equals("aminoAcids")) {
+					alphabet = "ARNDBCEQZGHILKMFPSTWYV";
+				}
 			}
 
 		} catch (IOException e) {

--- a/SequencePhenotype.java
+++ b/SequencePhenotype.java
@@ -70,7 +70,6 @@ public class SequencePhenotype implements Phenotype {
      * @return the sequence of the SequencePhenotype represented by this.
      */
     public String getSequence() {
-        System.out.println(this.sequence);
         return this.sequence;
     }
 

--- a/SequencePhenotype.java
+++ b/SequencePhenotype.java
@@ -1,4 +1,5 @@
 import java.lang.*;
+import java.util.Arrays;
 
 /**
  * <b>SequencePhenotype</b> represents a phenotype.
@@ -10,9 +11,11 @@ import java.lang.*;
 public class SequencePhenotype implements Phenotype {
 
     /**
-     * The valid letters that make up the sequence of this SequencePhenotype
+     * The valid letters that make up the sequence of this SequencePhenotype.
+     *
+     * Valid letters depend on the representation of the sequence (nucleotides or amino acids)
      */
-    public final char[] ALPHABET = "ARNDBCEQZGHILKMFPSTWYV".toCharArray();
+    public final char[] ALPHABET = Parameters.alphabet.toCharArray();
 
     /**
      * The sequence of this SequencePhenotype
@@ -22,7 +25,7 @@ public class SequencePhenotype implements Phenotype {
     /**
      * Run expensive tests iff DEBUG == true.
      */
-    public static final boolean DEBUG = false;
+    public static final boolean DEBUG = true;
 
     // Abstraction Function:
     // A SequencePhenotype, s, is null if s.sequence = null, otherwise s.sequence = sequence
@@ -67,6 +70,7 @@ public class SequencePhenotype implements Phenotype {
      * @return the sequence of the SequencePhenotype represented by this.
      */
     public String getSequence() {
+        System.out.println(this.sequence);
         return this.sequence;
     }
 
@@ -185,6 +189,15 @@ public class SequencePhenotype implements Phenotype {
         if (DEBUG)  {
             assert (this.sequence != null) : "sequence should never be null.";
             assert (this.sequence.length() > 0) : "sequence should never be empty.";
+
+            for (int i = 0; i < sequence.length(); i++) {
+                String [] alphabetString = new String(ALPHABET).split("");
+                String sequenceChar = ("" + sequence.charAt(i));
+                boolean contains = Arrays.stream(alphabetString).anyMatch(sequenceChar::equals);
+                if (!contains) {
+                    throw new IllegalArgumentException(sequenceChar + " is not a valid character!");
+                }
+            }
         }
     }
 }

--- a/TestSequencePhenotype.java
+++ b/TestSequencePhenotype.java
@@ -28,12 +28,26 @@ public class TestSequencePhenotype {
 		long seed = 5;
 		r.setSeed(seed);
 		emptyPheno = new SequencePhenotype();
-		simplePheno = new SequencePhenotype("ACGT");
+
 		// Create a small history of Sequence phenotypes
 		SequencePhenotype [] history = new SequencePhenotype[3];
-		history[0] = new SequencePhenotype("ATGT");
-		history[1] = new SequencePhenotype("ATCT");
-		history[2] = new SequencePhenotype("ATCA");
+
+		switch (Parameters.alphabet) {
+			case "nucleotides":
+				simplePheno = new SequencePhenotype("ACGT");
+
+				history[0] = new SequencePhenotype("ATGT");
+				history[1] = new SequencePhenotype("ATCT");
+				history[2] = new SequencePhenotype("ATCA");
+				break;
+			case "aminoAcids":
+				simplePheno = new SequencePhenotype("EQGZ");
+
+				history[0] = new SequencePhenotype("ESGZ");
+				history[1] = new SequencePhenotype("ESVZ");
+				history[2] = new SequencePhenotype("ESVY");
+				break;
+		}
 	}
 
 
@@ -43,10 +57,17 @@ public class TestSequencePhenotype {
 	@Test
 	public void testConstructors() {
 		// For now, assert that an emptyConstructor returns a single nucleotide
-		assertEquals(1, emptyPheno.getSequence().length());
+		assertEquals(Parameters.startingSequence.length(), emptyPheno.getSequence().length());
 
 		// Make sure simple constructor is fine
-		assertEquals("ACGT", simplePheno.getSequence());
+		switch (Parameters.alphabet) {
+			case "nucleotides":
+				assertEquals("ACGT", simplePheno.getSequence());
+				break;
+			case "aminoAcids":
+				assertEquals("EQGZ", simplePheno.getSequence());
+				break;
+		}
 	}
 
 	/**
@@ -54,18 +75,41 @@ public class TestSequencePhenotype {
 	 */
 	@Test
 	public void testDistance() {
-		// Hamming distance of same sequence
-		SequencePhenotype testPheno = new SequencePhenotype("ACGT");
-		assertEquals(0, simplePheno.distance(testPheno), 0.0);
+		SequencePhenotype testPheno;
+		SequencePhenotype diffPheno;
+		Exception exception;
+		SequencePhenotype shortPheno;
 
-		// Hamming distance of differing sequences
-		SequencePhenotype diffPheno = new SequencePhenotype("ATGT");
-		assertEquals(1, simplePheno.distance(diffPheno), 0.0);
+		switch (Parameters.alphabet) {
+			case "nucleotides":
+				// Hamming distance of same sequence
+				testPheno = new SequencePhenotype("ACGT");
+				assertEquals(0, simplePheno.distance(testPheno), 0.0);
 
-		// Hamming distance of sequences of different length
-		SequencePhenotype shortPheno = new SequencePhenotype("AT");
-		Exception exception = assertThrows(Exception.class, () -> testPheno.distance(shortPheno));
-		assertEquals("Sequence lengths are not equal!", exception.getMessage());
+				// Hamming distance of differing sequences
+				diffPheno = new SequencePhenotype("ATGT");
+				assertEquals(1, simplePheno.distance(diffPheno), 0.0);
+
+				// Hamming distance of sequences of different length
+				shortPheno = new SequencePhenotype("AT");
+				exception = assertThrows(Exception.class, () -> testPheno.distance(shortPheno));
+				assertEquals("Sequence lengths are not equal!", exception.getMessage());
+				break;
+			case "aminoAcids":
+				// Hamming distance of same sequence
+				testPheno = new SequencePhenotype("EQGZ");
+				assertEquals(0, simplePheno.distance(testPheno), 0.0);
+
+				// Hamming distance of differing sequences
+				diffPheno = new SequencePhenotype("ESGZ");
+				assertEquals(1, simplePheno.distance(diffPheno), 0.0);
+
+				// Hamming distance of sequences of different length
+				shortPheno = new SequencePhenotype("EQ");
+				exception = assertThrows(Exception.class, () -> testPheno.distance(shortPheno));
+				assertEquals("Sequence lengths are not equal!", exception.getMessage());
+				break;
+		}
 	}
 
 	/**
@@ -74,7 +118,15 @@ public class TestSequencePhenotype {
 	@Test
 	public void testGetSequence() {
 		// Assert the sequence was updated
-		assertEquals("ACGT", simplePheno.getSequence());
+
+		switch (Parameters.alphabet) {
+			case "nucleotides":
+				assertEquals("ACGT", simplePheno.getSequence());
+				break;
+			case "aminoAcids":
+				assertEquals("EQGZ", simplePheno.getSequence());
+				break;
+		}
 	}
 
 	/**
@@ -84,10 +136,23 @@ public class TestSequencePhenotype {
 	 */
 	@Test
 	public void testMutate() {
-		// Test new substitution mutate.
-		SequencePhenotype subPheno = (SequencePhenotype) simplePheno.mutate();
-		assertNotEquals(simplePheno.getSequence(), subPheno.getSequence());
-		assertEquals(simplePheno.getSequence().length(), subPheno.getSequence().length());
+		SequencePhenotype originalPheno;
+		switch (Parameters.alphabet) {
+			case "nucleotides":
+				originalPheno = new SequencePhenotype("ACGT");
+				// Test new substitution mutate.
+				originalPheno = originalPheno.mutate();
+				assertNotEquals(simplePheno.getSequence(), originalPheno.getSequence());
+				assertEquals(simplePheno.getSequence().length(), originalPheno.getSequence().length());
+				break;
+			case "aminoAcids":
+				originalPheno = new SequencePhenotype("EQGZ");
+				// Test new substitution mutate.
+				originalPheno = originalPheno.mutate();
+				assertNotEquals(simplePheno.getSequence(), originalPheno.getSequence());
+				assertEquals(simplePheno.getSequence().length(), originalPheno.getSequence().length());
+				break;
+		}
 	}
 
 	/**
@@ -104,7 +169,14 @@ public class TestSequencePhenotype {
 	 */
 	@Test
 	public void testToString() {
-		assertEquals("ACGT", simplePheno.toString());
+		switch (Parameters.alphabet) {
+			case "nucleotides":
+				assertEquals("ACGT", simplePheno.toString());
+				break;
+			case "aminoAcids":
+				assertEquals("EGQZ", simplePheno.toString());
+				break;
+		}
 	}
 
 	/**
@@ -113,17 +185,31 @@ public class TestSequencePhenotype {
 	@Test
 	public void testEquals() {
 		// Same SequencePhenotype objects are equal
-		assertTrue(emptyPheno.equals(emptyPheno));
+		assertEquals(emptyPheno, emptyPheno);
 
-		SequencePhenotype simplePhenoSame = new SequencePhenotype("ACGT");
-		SequencePhenotype simplePhenoDifferent = new SequencePhenotype("CCGT");
+		SequencePhenotype simplePhenoSame;
+		SequencePhenotype simplePhenoDifferent;
 
+		switch (Parameters.alphabet) {
+			case "nucleotides":
+				simplePhenoSame = new SequencePhenotype("ACGT");
+				simplePhenoDifferent = new SequencePhenotype("CCGT");
 
-		// SequencePhenotype objects with the same sequence are equal
-		assertTrue(simplePheno.equals(simplePhenoSame));
+				// SequencePhenotype objects with the same sequence are equal
+				assertEquals(simplePheno, simplePhenoSame);
+				// SequencePhenotype objects with different sequences are not equal
+				assertNotEquals(simplePheno, simplePhenoDifferent);
+				break;
+			case "aminoAcids":
+				simplePhenoSame = new SequencePhenotype("EGQZ");
+				simplePhenoDifferent = new SequencePhenotype("ESVY");
 
-		// SequencePhenotype objects with different sequences are not equal
-		assertFalse(simplePheno.equals(simplePhenoDifferent));
+				// SequencePhenotype objects with the same sequence are equal
+				assertEquals(simplePheno, simplePhenoSame);
+				// SequencePhenotype objects with different sequences are not equal
+				assertNotEquals(simplePheno, simplePhenoDifferent);
+				break;
+		}
 	}
 
 }

--- a/parameters.yml
+++ b/parameters.yml
@@ -64,3 +64,4 @@ sdStep: 0.3                                 # standard deviation of mutation siz
 mut2D: false                                # whether to mutate in a full 360 degree arc
 fixedStep: false                            # whether to fix step size, i.e. ignore sdStep
 startingSequence: "AGTC"                    # sequence for initial host immunity
+alphabetType: "aminoAcids"                  # options include: nucleotides, aminoAcids


### PR DESCRIPTION
## Description
Created a parameter in `parameters.yml` that will allow users to choose between representing `SequencePhenotype` with `nucleotides` or `aminoAcids`. 

- For `alphabetType: "nucleotides"`, valid characters are AGTC
- For `alphabetType: "aminoAcids"`, valid characters are ARNDBCEQZGHILKMFPSTWYV

The valid characters are hardcoded into `Parameters.java`, so the user only needs to choose between `"nucleotides"` and `"aminoAcids"`.

Closes #11 


## Tests
Updated `checkRep()` to check that this.sequence only contains valid letters based on ALPHABET. 
- Antigen.main() ran without any issues when `DEBUG == true`. 

Added switch statements in `TestSequencePhenotype.java` to tests all the instance methods. (Redundant code cannot be factored out without getting null pointer exceptions). 
- Passed every test

## Checklist:

* [x] The code uses informative and accurate variable and function names
* [x] The functionality is factored out into functions and methods with logical interfaces
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] TODOs have been eliminated from the code
* [x] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
* [ ] Documentation has been redeployed
