### PR TITLE
27-purifying-selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 /.classpath
 /.project
 .ipynb_checkpoints/
+.nfs*
 
 # IntelliJ generated files #
 *.iml

--- a/GeometricSeqPhenotype.java
+++ b/GeometricSeqPhenotype.java
@@ -247,6 +247,7 @@ public class GeometricSeqPhenotype extends GeometricPhenotype {
         int proteinMutationIndex = nucleotideMutationIndex / 3;
         boolean isEpitopeSite = Biology.SiteMutationVectors.VECTORS.getEpitopeSites().contains(proteinMutationIndex);
 
+
         // Determine whether the mutation occurred in an epitope or non-epitope site,
         // and update the counts of epitope and non-epitope mutations accordingly
         int eMutationNew = this.epitopeMutationCount;
@@ -254,6 +255,11 @@ public class GeometricSeqPhenotype extends GeometricPhenotype {
         if (isEpitopeSite) {
             eMutationNew += 1;
         } else {
+            // If non-epitope site, return this exact phenotype with probability Parameters.nonEpitopeAcceptance
+            double rejectionProb = Random.nextDouble(); // Uniform draw from 0.0 to 1.0
+            if (rejectionProb > Parameters.nonEpitopeAcceptance){
+                return this;
+            }
             neMutationNew += 1;
         }
 

--- a/Host.java
+++ b/Host.java
@@ -85,8 +85,9 @@ public class Host {
 	}
 
 	// make a new virus with the mutated phenotype
-	public void mutate() {
+	public Virus mutate() {
 		infection = infection.mutate();
+		return infection;
 	}
 
 	// remove random phenotype from host's immune profile, do nothing if empty

--- a/HostPopulation.java
+++ b/HostPopulation.java
@@ -350,7 +350,7 @@ public class HostPopulation {
 				Host iH = infecteds.get(index);			
 				Host sH = susceptibles.get(sndex);						
 				Virus v = iH.getInfection();
-								
+					
 				// attempt infection
 				Phenotype p = v.getPhenotype();		
 				Phenotype[] history = sH.getHistory();
@@ -360,6 +360,11 @@ public class HostPopulation {
 					removeSusceptible(sndex);
 					infecteds.add(sH);
 					cases++;
+				}
+				// If there is not fitness, assign now.
+				if (v.getFitness() == 0.0) {
+					double risk = getAverageRisk(p);
+					v.setFitness(risk);
 				}
 			
 			}
@@ -461,7 +466,10 @@ public class HostPopulation {
 			if (getI()>0) {
 				int index = getRandomI();
 				Host h = infecteds.get(index);
-				h.mutate();
+				Virus v = h.mutate();
+				Phenotype p = v.getPhenotype();
+				double risk = getAverageRisk(p);
+				v.setFitness(risk);
 			}
 		}			
 	}	

--- a/HostPopulation.java
+++ b/HostPopulation.java
@@ -466,8 +466,23 @@ public class HostPopulation {
 		}			
 	}	
 	
+	// Get average infection risk of a phenotype amongst a given sample size
+	private double getAverageRisk(Phenotype p) {
+		double sampleSize = (double) Parameters.fitnessSampleSize;
+		double averageRisk = 0;
+		for (int i = 0; i < Parameters.fitnessSampleSize; i++) {
+			Host h = getRandomHost();
+			Phenotype[] history = h.getHistory();
+			averageRisk += p.riskOfInfection(history);
+		}
+		averageRisk /= sampleSize;
+		return averageRisk;
+
+	}
+
 	// draw a Poisson distributed number of samples and add them to the VirusSample
 	// only sample after burnin is completed
+	// assign fitness values.
 	public void sample() {
 		if (getI()>0 && Parameters.day >= Parameters.burnin) {
 		
@@ -481,6 +496,9 @@ public class HostPopulation {
 				int index = getRandomI();
 				Host h = infecteds.get(index);
 				Virus v = h.getInfection();
+				Phenotype p = v.getPhenotype();
+				double risk = getAverageRisk(p);
+				v.setFitness(risk);
 				VirusTree.add(v);
 			}	
 		}

--- a/Parameters.java
+++ b/Parameters.java
@@ -35,6 +35,7 @@ public class Parameters {
 	public static String outPath = "output/"; // path to dump output files.
 	public static String outPrefix = "run-"; // suffix for output files.
 	public static String inPath = "input/"; // path to dump output files.
+	public static int fitnessSampleSize = 10000; // number of random hosts to sample for average infection risk
 
 	// metapopulation parameters
 	public static int demeCount = 3;
@@ -339,6 +340,9 @@ public class Parameters {
 									+ dmsDataLineCount);
 					throw new IOException();
 				}
+			}
+			if (map.get("fitnessSampleSize") != null) {
+				fitnessSampleSize = (int) map.get("fitnessSampleSize");
 			}
 		} catch (IOException e) {
 			System.out.println("Cannot load parameters.yml, using defaults");

--- a/Parameters.java
+++ b/Parameters.java
@@ -92,6 +92,7 @@ public class Parameters {
 	public static String DMSFile = null; // name of DMS csv file: must have 21 columns (site number and amino acid
 	                                     // preferences ordered alphabetically) and rows must equal the number of
 	                                     // amino acid sites in the virus sequence)
+	public static double nonEpitopeAcceptance = 1.0; // probability of accepting a non-epitope mutation
 
 	// measured in years, starting at burnin
 	public static double getDate() {
@@ -316,6 +317,9 @@ public class Parameters {
 			}
 			if (map.get("transitionTransversionRatio") != null) {
 				transitionTransversionRatio = (double) map.get("transitionTransversionRatio");
+			}
+			if (map.get("nonEpitopeAcceptance") != null){
+				nonEpitopeAcceptance = (double) map.get("nonEpitopeAcceptance");
 			}
 			if (map.get("DMSFile") != null) {
 				DMSFile = (String) map.get("DMSFile");

--- a/Simulation.java
+++ b/Simulation.java
@@ -173,14 +173,6 @@ public class Simulation {
 
 	}
 
-	// Loop through virus tree and calculate average infection risk
-	public void setFitnessValues() {
-		for (Virus v : VirusTree.getTips()){
-			Phenotype p = v.getPhenotype();
-			double risk = getAverageRisk(p);
-			v.setFitness(risk);
-		}
-	}
 
 	public void printImmunity() {
 
@@ -458,8 +450,6 @@ public class Simulation {
 			VirusTree.flip();
 		}
 
-		// Assign fitness value estimates.
-		setFitnessValues();
 
 
 		// Summary

--- a/Simulation.java
+++ b/Simulation.java
@@ -159,17 +159,27 @@ public class Simulation {
 		return hp.getRandomHost();
 	}
 
+	// Get average infection risk of a phenotype amongst a given sample size
 	public double getAverageRisk(Phenotype p) {
-
+		double sampleSize = (double) Parameters.fitnessSampleSize;
 		double averageRisk = 0;
-		for (int i = 0; i < 10000; i++) {
+		for (int i = 0; i < Parameters.fitnessSampleSize; i++) {
 			Host h = getRandomHost();
 			Phenotype[] history = h.getHistory();
 			averageRisk += p.riskOfInfection(history);
 		}
-		averageRisk /= 10000.0;
+		averageRisk /= sampleSize;
 		return averageRisk;
 
+	}
+
+	// Loop through virus tree and calculate average infection risk
+	public void setFitnessValues() {
+		for (Virus v : VirusTree.getTips()){
+			Phenotype p = v.getPhenotype();
+			double risk = getAverageRisk(p);
+			v.setFitness(risk);
+		}
 	}
 
 	public void printImmunity() {
@@ -447,6 +457,9 @@ public class Simulation {
 			VirusTree.rotate();
 			VirusTree.flip();
 		}
+
+		// Assign fitness value estimates.
+		setFitnessValues();
 
 
 		// Summary

--- a/Virus.java
+++ b/Virus.java
@@ -9,6 +9,7 @@ public class Virus {
 	private Phenotype phenotype;
 	private double birth;		// measured in years relative to burnin
 	private int deme;
+	private double fitness; 	// average risk of infection of 100,000 hosts
 	
 	// additional reconstruction fields
 	private boolean marked;
@@ -87,6 +88,12 @@ public class Virus {
 	}
 	public void incrementCoverage() {
 		coverage++;
+	}
+	public double getFitness(){
+		return fitness;
+	}
+	public void setFitness(double f){
+		fitness = f;
 	}
 	
 	// add virus node as child if does not already exist

--- a/VirusTree.java
+++ b/VirusTree.java
@@ -633,7 +633,7 @@ public class VirusTree {
 				tipStream.printf(
 						"\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", "name",
 						"year", "trunk", "tip", "mark", "location", "layout", "nucleotideSequence", "ag1", "ag2",
-						"epitopeMutationCount", "nonepitopeMutationCount,", "fitness");
+						"epitopeMutationCount", "nonepitopeMutationCount", "fitness");
 			} else {
 				tipStream.printf("\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", "name", "year",
 						"trunk", "tip", "mark", "location", "layout", "ag1", "ag2", "fitness");
@@ -660,9 +660,9 @@ public class VirusTree {
 			for (Virus v : postOrderNodes()) {
 				if (v.getParent() != null) {
 					Virus vp = v.getParent();
-					branchStream.printf("{\"%s\",%.4f,%d,%d,%d,%d,%.4f,%s}\t", v, v.getBirth(), v.isTrunk() ? 1 : 0,
+					branchStream.printf("{\"%s\",%.4f,%.4f,%d,%d,%d,%d,%.4f,%s}\t", v, v.getBirth(), v.getFitness(), v.isTrunk() ? 1 : 0,
 							v.isTip() ? 1 : 0, v.isMarked() ? 1 : 0, v.getDeme(), v.getLayout(), v.getPhenotype());
-					branchStream.printf("{\"%s\",%.4f,%d,%d,%d,%d,%.4f,%s}\t", vp, vp.getBirth(), vp.isTrunk() ? 1 : 0,
+					branchStream.printf("{\"%s\",%.4f,%.4f,%d,%d,%d,%d,%.4f,%s}\t", vp, vp.getBirth(), vp.getFitness(), vp.isTrunk() ? 1 : 0,
 							vp.isTip() ? 1 : 0, v.isMarked() ? 1 : 0, vp.getDeme(), vp.getLayout(), vp.getPhenotype());
 					branchStream.printf("%d\n", vp.getCoverage());
 				}

--- a/VirusTree.java
+++ b/VirusTree.java
@@ -695,7 +695,7 @@ public class VirusTree {
 	}
 
 	private static void printSequence(Virus v, PrintStream fastaStream, int fastaSequenceNum) {
-		fastaStream.printf(">seq%d|%f|%s|%f\n", fastaSequenceNum, v.getBirth(), Parameters.demeNames[v.getDeme()], v.getFitness());
+		fastaStream.printf(">seq%d|%f|%f\n", fastaSequenceNum, v.getBirth(), v.getFitness());
 
 		String virusPhenotype = v.getPhenotype().toString();
 		String sequence = virusPhenotype.split(",")[0];

--- a/VirusTree.java
+++ b/VirusTree.java
@@ -631,16 +631,16 @@ public class VirusTree {
 			PrintStream tipStream = new PrintStream(tipFile);
 			if (Parameters.phenotypeSpace.equals("geometricSeq")) {
 				tipStream.printf(
-						"\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", "name",
+						"\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", "name",
 						"year", "trunk", "tip", "mark", "location", "layout", "nucleotideSequence", "ag1", "ag2",
-						"epitopeMutationCount", "nonepitopeMutationCount");
+						"epitopeMutationCount", "nonepitopeMutationCount,", "fitness");
 			} else {
-				tipStream.printf("\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", "name", "year",
-						"trunk", "tip", "mark", "location", "layout", "ag1", "ag2");
+				tipStream.printf("\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", "name", "year",
+						"trunk", "tip", "mark", "location", "layout", "ag1", "ag2", "fitness");
 			}
 			for (Virus v : tips) {
-				tipStream.printf("\"%s\",%.4f,%d,%d,%d,%d,%.4f,%s\n", v, v.getBirth(), v.isTrunk() ? 1 : 0,
-						v.isTip() ? 1 : 0, v.isMarked() ? 1 : 0, v.getDeme(), v.getLayout(), v.getPhenotype());
+				tipStream.printf("\"%s\",%.4f,%d,%d,%d,%d,%.4f,%s,%.4f\n", v, v.getBirth(), v.isTrunk() ? 1 : 0,
+						v.isTip() ? 1 : 0, v.isMarked() ? 1 : 0, v.getDeme(), v.getLayout(), v.getPhenotype(), v.getFitness());
 			}
 			tipStream.close();
 		} catch (IOException ex) {
@@ -695,7 +695,7 @@ public class VirusTree {
 	}
 
 	private static void printSequence(Virus v, PrintStream fastaStream, int fastaSequenceNum) {
-		fastaStream.printf(">seq%d|%f|%s\n", fastaSequenceNum, v.getBirth(), Parameters.demeNames[v.getDeme()]);
+		fastaStream.printf(">seq%d|%f|%s|%f\n", fastaSequenceNum, v.getBirth(), Parameters.demeNames[v.getDeme()], v.getFitness());
 
 		String virusPhenotype = v.getPhenotype().toString();
 		String sequence = virusPhenotype.split(",")[0];

--- a/parameters.yml
+++ b/parameters.yml
@@ -7,6 +7,7 @@ burnin: 0                                   # days to wait before logging output
 endDay: 1000                                # number of days to simulate
 deltaT: 0.1                                 # number of days to move forward in a single timestep
 printStep: 50                               # print to out.timeseries every X days
+fitnessSampleSize: 100000                   # number of random hosts to sample for average infection risk 
 tipSamplingRate: 0.0002                     # store X samples per deme per day
 tipSamplesPerDeme: 2000                     # cap number of samples per deme
 tipSamplingProportional: true               # whether to sample proportional to prevalence

--- a/parameters.yml
+++ b/parameters.yml
@@ -4,7 +4,7 @@
 
 # simulation parameters
 burnin: 0                                   # days to wait before logging output 
-endDay: 1000                                # number of days to simulate
+endDay: 600                                # number of days to simulate
 deltaT: 0.1                                 # number of days to move forward in a single timestep
 printStep: 50                               # print to out.timeseries every X days
 fitnessSampleSize: 100000                   # number of random hosts to sample for average infection risk 

--- a/parameters.yml
+++ b/parameters.yml
@@ -75,4 +75,5 @@ predefinedVectors: false                     # whether to use predefined vectors
 meanStepEpitope: 0.3                        # mean mutation size for epitopes
 sdStepEpitope: 0.3                          # standard deviation of mutation size for epitopes
 transitionTransversionRatio: 5.0            # transition/transversion rate ratio, k
+nonEpitopeAcceptance: 1.0                   # probability of accepting a non-epitope mutation
 DMSFile:                                    # name of DMS csv file: must have 21 columns (site number and amino acid preferences ordered alphabetically) and rows must be in sequential order and equal the number of amino acid sites in the virus sequence

--- a/parameters.yml
+++ b/parameters.yml
@@ -7,7 +7,7 @@ burnin: 0                                   # days to wait before logging output
 endDay: 600                                # number of days to simulate
 deltaT: 0.1                                 # number of days to move forward in a single timestep
 printStep: 50                               # print to out.timeseries every X days
-fitnessSampleSize: 100000                   # number of random hosts to sample for average infection risk 
+fitnessSampleSize: 100                   # number of random hosts to sample for average infection risk 
 tipSamplingRate: 0.0002                     # store X samples per deme per day
 tipSamplesPerDeme: 2000                     # cap number of samples per deme
 tipSamplingProportional: true               # whether to sample proportional to prevalence


### PR DESCRIPTION
## Description

Add "purifying selection" -- not really, just toning down non-epitope mutation counts. Only mutate non-epitope sites with a given probability. If no mutation event occurs, return old virus phenotype.

Closes #27

## Tests

Test runs will be in antigen-experiments repo after completion of analysis


## Checklist:

* [x] The code uses informative and accurate variable and function names
* [x] The functionality is factored out into functions and methods with logical interfaces
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] TODOs have been eliminated from the code
* [x] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
* [ ] Documentation has been redeployed
