### PR TITLE
add contact rate recording to `HostPopulation.printImmuneHistories()`

### DIFF
--- a/HostPopulation.java
+++ b/HostPopulation.java
@@ -21,6 +21,7 @@ public class HostPopulation {
 	
 	private int newContacts;
 	private int newRecoveries;
+	private double contactRate;
 		
 	// construct population, using Virus v as initial infection
 	public HostPopulation(int d) {
@@ -335,6 +336,7 @@ public class HostPopulation {
 	public void recordContacts() {
 		// each infected makes I->S contacts on a per-day rate of beta * S/N
 		double totalContactRate = getI() * getPrS() * Parameters.beta * Parameters.getSeasonality(deme) * Parameters.deltaT;
+		contactRate = totalContactRate;
 		newContacts = Random.nextPoisson(totalContactRate);			
 	}
 
@@ -619,6 +621,8 @@ public class HostPopulation {
 	}
 	
 	public void printHostImmuneHistories(PrintStream stream, int n){
+		//first, print the contact rate
+		stream.printf("contactRate:\t" + "%.4f\n", contactRate);
 		// grab n random hosts and print their immune histories
 		for (int i = 0; i < n; i++) {
 			Host h = getRandomHost();

--- a/Simulation.java
+++ b/Simulation.java
@@ -425,7 +425,6 @@ public class Simulation {
 				// print immunity if needed
 				if (Parameters.sampleHostImmunity && Parameters.day % (double) Parameters.printHostImmunityStep < Parameters.deltaT) {
 					// Test print
-					System.out.println("Immunity sample being taken...");
 					historyStream.printf("date:\t" + "%.2f\n", Parameters.day);
 					printHostImmuneHistories(historyStream);
 					


### PR DESCRIPTION
## Description

Add temporal contact rates for each deme during immune history printing for future benchmarking.

Closes #32


## Tests

Re-ran the small base-case build, confirmed results were being printed as expected.


## Checklist:

* [x] The code uses informative and accurate variable and function names
* [x] The functionality is factored out into functions and methods with logical interfaces
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Commenting and/or documentation is sufficient for others to be able to understand intent and implementation
* [x] TODOs have been eliminated from the code
* [x] The corresponding issue number (e.g. `#278`) has been searched for in the code to find relevant notes
* [x] Documentation has been redeployed
