### PR TITLE
Remove getAverageRisk from HostPopulation.mutate()

### DIFF
--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -491,17 +491,7 @@ public class HostPopulation {
       if (getI() > 0) {
         int index = getRandomI();
         Host h = infecteds.get(index);
-        Virus v = h.mutate();
-        Phenotype p = v.getPhenotype();
-        double averageRisk = getAverageRisk(p);
-        double seasonality = Parameters.getSeasonality(deme);
-        double probSusceptible = getPrS();
-        double seasonalFitness = averageRisk * seasonality * probSusceptible;
-
-        v.setAverageInfectionRisk(averageRisk);
-        v.setDemeSeasonality(seasonality);
-        v.setProbSusceptible(probSusceptible);
-        v.setFitness(seasonalFitness);
+        h.mutate();
       }
     }
   }

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -426,6 +426,17 @@ public class HostPopulation {
           infecteds.add(sH);
           cases++;
         }
+        if (v.getFitness() == 0.0) {
+          double averageRisk = getAverageRisk(p);
+          double seasonality = Parameters.getSeasonality(deme);
+          double probSusceptible = getPrS();
+          double seasonalFitness = averageRisk * seasonality * probSusceptible;
+
+          v.setAverageInfectionRisk(averageRisk);
+          v.setDemeSeasonality(seasonality);
+          v.setProbSusceptible(probSusceptible);
+          v.setFitness(seasonalFitness);
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #45

## Summary
Removes the 9-line fitness-computation block from `HostPopulation.mutate()`. Previously, every mutation event triggered `getAverageRisk()` (100 random host samples × `riskOfInfection`), generating ~1.1M calls per step at peak infection — 93% of all such calls. Fitness is already computed lazily in `distributeContacts()` when `v.getFitness() == 0.0` and always recomputed in `sample()` at tip time, so the call in `mutate()` was redundant. Viruses that mutate but whose host recovers before any contact (~17%) will retain `fitness == 0.0`, which is acceptable since they are never sampled.

## Assumptions & Decisions
None.