### PR TITLE
Guard fitness computation behind burnin in contact methods

### DIFF
--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -378,8 +378,8 @@ public class HostPopulation {
           infecteds.add(sH);
           cases++;
         }
-        // If there is not fitness, assign now.
-        if (v.getFitness() == 0.0) {
+        // Fitness is only needed post-burnin when viruses are sampled into the tree.
+        if (v.getFitness() == 0.0 && Parameters.day >= Parameters.burnin) {
           double averageRisk = getAverageRisk(p);
           double seasonality = Parameters.getSeasonality(deme);
           double probSusceptible = getPrS();
@@ -426,7 +426,7 @@ public class HostPopulation {
           infecteds.add(sH);
           cases++;
         }
-        if (v.getFitness() == 0.0) {
+        if (v.getFitness() == 0.0 && Parameters.day >= Parameters.burnin) {
           double averageRisk = getAverageRisk(p);
           double seasonality = Parameters.getSeasonality(deme);
           double probSusceptible = getPrS();

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -491,17 +491,7 @@ public class HostPopulation {
       if (getI() > 0) {
         int index = getRandomI();
         Host h = infecteds.get(index);
-        Virus v = h.mutate();
-        Phenotype p = v.getPhenotype();
-        double averageRisk = getAverageRisk(p);
-        double seasonality = Parameters.getSeasonality(deme);
-        double probSusceptible = getPrS();
-        double seasonalFitness = averageRisk * seasonality * probSusceptible;
-
-        v.setAverageInfectionRisk(averageRisk);
-        v.setDemeSeasonality(seasonality);
-        v.setProbSusceptible(probSusceptible);
-        v.setFitness(seasonalFitness);
+        h.mutate();
       }
     }
   }

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -426,6 +426,17 @@ public class HostPopulation {
           infecteds.add(sH);
           cases++;
         }
+        if (v.getFitness() == 0.0) {
+          double averageRisk = getAverageRisk(p);
+          double seasonality = Parameters.getSeasonality(deme);
+          double probSusceptible = getPrS();
+          double seasonalFitness = averageRisk * seasonality * probSusceptible;
+
+          v.setAverageInfectionRisk(averageRisk);
+          v.setDemeSeasonality(seasonality);
+          v.setProbSusceptible(probSusceptible);
+          v.setFitness(seasonalFitness);
+        }
       }
     }
   }

--- a/src/test/java/org/antigen/host/TestHostPopulationBurninGuard.java
+++ b/src/test/java/org/antigen/host/TestHostPopulationBurninGuard.java
@@ -47,8 +47,7 @@ public class TestHostPopulationBurninGuard {
     hp.recordContacts();
     hp.distributeContacts();
 
-    assertEquals(
-        "Fitness should not be assigned during burnin", 0.0, infector.getFitness(), 0.0);
+    assertEquals("Fitness should not be assigned during burnin", 0.0, infector.getFitness(), 0.0);
   }
 
   /** Fitness MUST be set on a virus post-burnin (day == burnin boundary). */

--- a/src/test/java/org/antigen/host/TestHostPopulationBurninGuard.java
+++ b/src/test/java/org/antigen/host/TestHostPopulationBurninGuard.java
@@ -1,0 +1,70 @@
+package org.antigen.host;
+
+import static org.junit.Assert.*;
+
+import org.antigen.core.Parameters;
+import org.antigen.virus.Virus;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests that the burnin guard in distributeContacts() correctly suppresses fitness computation
+ * during burnin and permits it post-burnin.
+ */
+public class TestHostPopulationBurninGuard {
+
+  @Before
+  public void setUp() {
+    Parameters.load();
+    Parameters.initialize();
+    // Single deme, small population for speed
+    Parameters.demeCount = 1;
+    Parameters.demeNames = new String[] {"test"};
+    Parameters.initialNs = new int[] {10};
+    Parameters.initialDeme = 1;
+    Parameters.initialI = 1;
+    Parameters.initialPrR = 0.0;
+    Parameters.swapDemography = false;
+    Parameters.transcendental = false;
+    Parameters.waning = false;
+    Parameters.fitnessSampleSize = 5;
+    Parameters.deltaT = 1.0;
+    // High beta guarantees Poisson contact draw >> 0 so distributeContacts() runs its body
+    Parameters.beta = 10000.0;
+  }
+
+  /** Fitness must NOT be set on a virus during burnin. */
+  @Test
+  public void testFitnessNotSetDuringBurnin() {
+    Parameters.day = 0.0;
+    Parameters.burnin = 100;
+
+    HostPopulation hp = new HostPopulation(0);
+    Virus infector = hp.getRandomInfection();
+    assertNotNull(infector);
+    assertEquals(0.0, infector.getFitness(), 0.0);
+
+    hp.recordContacts();
+    hp.distributeContacts();
+
+    assertEquals(
+        "Fitness should not be assigned during burnin", 0.0, infector.getFitness(), 0.0);
+  }
+
+  /** Fitness MUST be set on a virus post-burnin (day == burnin boundary). */
+  @Test
+  public void testFitnessSetPostBurnin() {
+    Parameters.burnin = 0;
+    Parameters.day = 0.0; // day >= burnin, so guard passes
+
+    HostPopulation hp = new HostPopulation(0);
+    Virus infector = hp.getRandomInfection();
+    assertNotNull(infector);
+    assertEquals(0.0, infector.getFitness(), 0.0);
+
+    hp.recordContacts();
+    hp.distributeContacts();
+
+    assertTrue("Fitness should be assigned post-burnin", infector.getFitness() > 0.0);
+  }
+}


### PR DESCRIPTION
Closes #46

## Summary
Adds `&& Parameters.day >= Parameters.burnin` to the `v.getFitness() == 0.0` blocks in both `distributeContacts()` and `betweenDemeContact()`. During burnin no viruses are sampled into the tree, so internal-node fitness values are irrelevant — skipping `getAverageRisk()` (100 host samples × `riskOfInfection` each) for the entire burnin period eliminates the remaining costly fitness calls left after #45. When `burnin == 0` the guard is always true and behavior is identical to before.

## Assumptions & Decisions
Applied the same burnin guard to `betweenDemeContact()` as well as `distributeContacts()`, since the former received the lazy-fitness block in #45 and omitting the guard there would be inconsistent.