### PR TITLE
Port out.histories.csv centroid output

### DIFF
--- a/docs/user-guide/immunity-centroids.md
+++ b/docs/user-guide/immunity-centroids.md
@@ -14,14 +14,19 @@ Each host maintains an immune history from previous infections. The immunity cen
 | `printHostImmunityStep` | 365 | Sampling interval in days |
 | `hostImmunitySamplesPerDeme` | [10000, 10000, 10000] | Hosts sampled per deme |
 
-## Output File: `out.histories.csv`
+## Output Files
 
-When `sampleHostImmunity: true`, antigen-prime outputs `out.histories.csv` with columns:
+When `sampleHostImmunity: true`, antigen-prime writes two files on each `printHostImmunityStep` interval from the **same sampled hosts**:
+
+- **`out.histories.csv`** — per-deme and global centroids (described below)
+- **`out.histories`** — full immune history coordinates for every sampled host, grouped by deme; useful for reviewing the raw data behind the centroids
+
+### `out.histories.csv` columns
 
 | Column | Description |
 |--------|-------------|
 | `year` | Simulation time in years |
-| `deme` | Geographic deme name or "total" for global |
+| `deme` | Geographic deme name or "global" for global aggregate |
 | `ag1` | Centroid x-coordinate in antigenic space |
 | `ag2` | Centroid y-coordinate in antigenic space |
 | `naive_fraction` | Fraction of sampled hosts with no immune history |
@@ -33,7 +38,7 @@ year,deme,ag1,ag2,naive_fraction,experienced_hosts
 0.0000,north,-6.000000,0.000000,0.4981,5019
 0.0000,tropics,-6.000000,0.000000,0.4968,5032
 0.0000,south,-6.000000,0.000000,0.5070,4930
-0.0000,total,-6.000000,0.000000,0.5006,14981
+0.0000,global,-6.000000,0.000000,0.5006,14981
 1.0000,north,-2.537124,-0.014044,0.2117,7883
 ```
 
@@ -51,7 +56,7 @@ Where:
 - $n_{exp}$ = number of experienced (non-naive) hosts
 - $h_i^{(\text{recent})}$ = antigenic coordinates of host $i$'s most recent infection
 
-The global ("total") centroid is computed as a weighted average across demes, weighted by number of experienced hosts.
+The global (`global`) centroid is computed as a weighted average across demes, weighted by number of experienced hosts.
 
 ## Using Centroids for Fitness Calculation
 

--- a/docs/user-guide/output-analysis.md
+++ b/docs/user-guide/output-analysis.md
@@ -1,0 +1,168 @@
+# Output Analysis Guide
+
+antigen-prime generates several output files that capture different aspects of the simulation. This guide explains what each file contains, how to interpret the data, and how to perform common analyses.
+
+## Output File Overview
+
+| File             | Content                   | Primary Use                                                                 |
+| ---------------- | ------------------------- | --------------------------------------------------------------------------- |
+| `out.timeseries` | Epidemic curves over time | Extracting case counts, attack rates, and other epidemic summary statistics |
+| `out.summary`    | Summary statistics        | Overall epidemic characteristics                                            |
+| `out.tips`       | Sampled virus data        | Assessing antigenic evolution, post-simulation variant assignment           |
+| `out.branches`   | Tree branch structure     | Phylogenetic tree reconstruction with full node metadata                    |
+| `out.fasta`      | Virus sequences           | Sequence analysis, alignment, molecular evolution (GeometricSeq only)       |
+| `out.tree`       | Newick tree format        | Tree visualization in standard phylogenetic software                        |
+| `out.immunity`   | Final immunity landscape  | Population-level immunity snapshot at simulation end (optional)             |
+| `out.histories`  | Host immune histories     | Raw per-host immune coordinates for sampled hosts at each sampling interval (optional) |
+| `out.histories.csv` | Population immunity centroids | Per-deme average antigenic position of most-recent infections (optional) |
+
+## Core Output Files
+
+### 1. Timeseries Data (`out.timeseries`)
+
+**Purpose:** Tracks epidemic dynamics over time with global and per-deme breakdown
+
+**Format:** Tab-separated values with columns:
+```
+date  diversity  tmrca  netau  serialInterval  antigenicDiversity  totalN  totalS  totalI  totalR  totalCases  [per-deme columns]
+```
+
+**Column Descriptions:**
+- `date`: Simulation date in years (calculated from days post-burnin)
+- `diversity`: Mean genetic diversity of circulating viruses
+- `tmrca`: Time to most recent common ancestor (halved)
+- `netau`: Effective population size × generation time
+- `serialInterval`: Mean time between successive infections
+- `antigenicDiversity`: Mean diversity in antigenic phenotype space
+- `totalN`: Total population size across all demes
+- `totalS`: Total susceptible individuals
+- `totalI`: Total infected individuals  
+- `totalR`: Total recovered individuals
+- `totalCases`: Total new cases this timestep
+
+**Per-deme columns** (repeated for each deme with deme name prefix):
+- `{demeName}Diversity`: Genetic diversity in this deme
+- `{demeName}Tmrca`: TMRCA for this deme
+- `{demeName}Netau`: Ne×tau for this deme
+- `{demeName}SerialInterval`: Serial interval for this deme
+- `{demeName}AntigenicDiversity`: Antigenic diversity in this deme
+- `{demeName}N`: Population size
+- `{demeName}S`: Susceptible count
+- `{demeName}I`: Infected count
+- `{demeName}R`: Recovered count
+- `{demeName}Cases`: New cases
+
+
+### 2. Summary Statistics (`out.summary`)
+
+**Purpose:** Mean values of key metrics over the simulation period (post-burnin)
+
+**Format:** Two-column tab-separated values:
+```
+parameter	full
+endDate	5.4795
+diversity	0.3421
+tmrca	1.2345
+...
+```
+
+**Content includes:**
+- `endDate`: Final simulation date in years
+- `diversity`: Mean genetic diversity
+- `tmrca`: Mean time to most recent common ancestor
+- `netau`: Mean effective population size × generation time
+- `serialInterval`: Mean serial interval
+- `antigenicDiversity`: Mean antigenic diversity
+- `N`: Mean total population size
+- `S`: Mean susceptible count
+- `I`: Mean infected count
+- `R`: Mean recovered count
+- `cases`: Mean new cases per timestep
+- `sideBranchRate`: Mutation rate on side branches (appended)
+- `trunkRate`: Mutation rate on trunk lineage (appended)
+- `mkRatio`: McDonald-Kreitman ratio (trunk rate / side branch rate) (appended)
+
+### 3. Virus Sample Data (`out.tips`)
+
+**Purpose:** Sample of viruses collected throughout simulation for phylogenetic analysis
+
+**Format:** Tab-separated with columns:
+```
+sample  date  deme  traitA  traitB  [additional phenotype traits]
+```
+
+**Column Descriptions:**
+- `sample`: Unique virus identifier
+- `date`: Collection date (simulation day)
+- `deme`: Geographic origin
+- `traitA`, `traitB`: Antigenic phenotype coordinates
+- Additional columns for higher-dimensional phenotypes or sequence data
+
+
+### 4. Phylogenetic Structure (`out.branches`)
+
+**Purpose:** Complete phylogenetic tree structure with detailed metadata for each branch
+
+**Format:** Tab-separated with two virus objects and coverage count per line:
+```
+{child_virus_object}    {parent_virus_object}    coverage_count
+```
+
+Each virus object contains: `{name, birth_time, fitness, trunk_flag, tip_flag, marked_flag, deme, layout, phenotype}`
+
+
+### 5. Sequence Data (`out.fasta`)
+
+**Purpose:** Virus sequences in standard FASTA format (only for GeometricSeqPhenotype)
+
+**Format:** Standard FASTA with headers containing metadata:
+```
+>seq0|12.3456|0.9876
+ATGCGATCGATCGATCG...
+>seq1|12.4567|0.9765
+ATGCGATCGATCGATCG...
+```
+
+Header format: `>seq{number}|{birth_time}|{fitness}`
+
+## Optional Output Files
+
+### Host Immunity (`out.immunity`)
+
+**Enabled by:** `immunityReconstruction: true`
+
+**Purpose:** Snapshot of population immunity landscape at simulation end
+
+**Format:** CSV grid of infection risk values across phenotype space
+- Rows represent x-coordinates in phenotype space
+- Columns represent y-coordinates in phenotype space  
+- Values are average infection risks (0-1) based on population's immune histories
+- Grid samples phenotype space every 0.5 units
+
+### Host Histories (`out.histories` and `out.histories.csv`)
+
+**Enabled by:** `sampleHostImmunity: true`
+
+**Purpose:** Both files are written on the same schedule (`printHostImmunityStep`) from the **same sampled hosts**, so they form a coherent pair — the raw histories are the exact dataset used to compute the centroids.
+
+**`out.histories`** — raw per-host coordinates: for each sampling interval, prints the contact rate and the full immune history coordinates of every sampled host, grouped by deme.
+
+**`out.histories.csv`** — per-deme and global centroids: CSV with columns `year,deme,ag1,ag2,naive_fraction,experienced_hosts`. One row per deme plus a `global` aggregate row. See the [immunity centroids guide](immunity-centroids.md) for full details.
+
+**Number of hosts sampled per deme** is set by `hostImmunitySamplesPerDeme`. Demes with a value of 0 are skipped.
+
+## Interpretation Guidelines
+
+### What Results Mean
+
+**High diversity:** Active evolution, multiple co-circulating strains
+**Low diversity:** Genetic bottlenecks, recent population expansion
+**Oscillating prevalence:** Seasonal dynamics, antigenic cycling
+**Rapid antigenic evolution:** Strong immune pressure, immune escape
+
+### Common Pitfalls
+
+1. **Burn-in effects:** Always exclude burn-in period from analysis
+2. **Stochastic noise:** Use multiple replicates for robust conclusions
+3. **Parameter sensitivity:** Test key results across parameter ranges
+4. **Scale effects:** Results may depend on population size and timestep

--- a/src/main/java/org/antigen/core/Simulation.java
+++ b/src/main/java/org/antigen/core/Simulation.java
@@ -216,9 +216,10 @@ public class Simulation {
     }
   }
 
-  public void printPopulationImmunityCentroids(PrintStream historyStream, boolean writeHeader) {
+  public void writeImmunityOutputs(
+      PrintStream csvStream, PrintStream rawStream, boolean writeHeader) {
     if (writeHeader) {
-      historyStream.println("year,deme,ag1,ag2,naive_fraction,experienced_hosts");
+      csvStream.println("year,deme,ag1,ag2,naive_fraction,experienced_hosts");
     }
     double year = Parameters.day / 365.0;
     double globalSumAg1 = 0.0;
@@ -228,9 +229,14 @@ public class Simulation {
 
     for (int i = 0; i < Parameters.demeCount; i++) {
       int nSamples = Parameters.hostImmunitySamplesPerDeme[i];
-      ImmunitySummary summary = demes.get(i).getPopulationImmunitySummary(nSamples);
+      if (nSamples == 0) continue;
+      HostPopulation hp = demes.get(i);
+      List<Host> sampled = hp.sampleHosts(nSamples);
+      ImmunitySummary summary = hp.getPopulationImmunitySummary(sampled);
+      hp.printHostImmuneHistories(rawStream, sampled);
+
       if (summary.hasValidCentroid()) {
-        historyStream.printf(
+        csvStream.printf(
             "%.4f,%s,%.6f,%.6f,%.4f,%d%n",
             year,
             Parameters.demeNames[i],
@@ -241,7 +247,7 @@ public class Simulation {
         globalSumAg1 += summary.getCentroid()[0] * summary.getExperiencedHosts();
         globalSumAg2 += summary.getCentroid()[1] * summary.getExperiencedHosts();
       } else {
-        historyStream.printf(
+        csvStream.printf(
             "%.4f,%s,NaN,NaN,%.4f,%d%n",
             year,
             Parameters.demeNames[i],
@@ -253,7 +259,7 @@ public class Simulation {
     }
 
     if (globalExperiencedHosts > 0) {
-      historyStream.printf(
+      csvStream.printf(
           "%.4f,global,%.6f,%.6f,%.4f,%d%n",
           year,
           globalSumAg1 / globalExperiencedHosts,
@@ -261,7 +267,7 @@ public class Simulation {
           1.0 - (double) globalExperiencedHosts / globalTotalSamples,
           globalExperiencedHosts);
     } else {
-      historyStream.printf("%.4f,global,NaN,NaN,1.0000,%d%n", year, 0);
+      csvStream.printf("%.4f,global,NaN,NaN,1.0000,%d%n", year, 0);
     }
   }
 
@@ -456,10 +462,14 @@ public class Simulation {
 
       File outDirs = new File(Parameters.outPath);
       outDirs.mkdirs();
-      File historyFile = new File("out.histories.csv");
-      historyFile.delete();
-      historyFile.createNewFile();
-      PrintStream historyStream = new PrintStream(historyFile);
+      File historyCsvFile = new File("out.histories.csv");
+      historyCsvFile.delete();
+      historyCsvFile.createNewFile();
+      PrintStream historyCsvStream = new PrintStream(historyCsvFile);
+      File historyRawFile = new File("out.histories");
+      historyRawFile.delete();
+      historyRawFile.createNewFile();
+      PrintStream historyRawStream = new PrintStream(historyRawFile);
       boolean historiesHeaderWritten = false;
       File seriesFile = new File("out.timeseries");
       seriesFile.delete();
@@ -484,7 +494,7 @@ public class Simulation {
         // print immunity if needed
         if (Parameters.sampleHostImmunity
             && Parameters.day % (double) Parameters.printHostImmunityStep < Parameters.deltaT) {
-          printPopulationImmunityCentroids(historyStream, !historiesHeaderWritten);
+          writeImmunityOutputs(historyCsvStream, historyRawStream, !historiesHeaderWritten);
           historiesHeaderWritten = true;
         }
 
@@ -504,7 +514,8 @@ public class Simulation {
       }
 
       seriesStream.close();
-      historyStream.close();
+      historyCsvStream.close();
+      historyRawStream.close();
 
       writeDataCSV();
     } catch (IOException ex) {

--- a/src/main/java/org/antigen/core/Simulation.java
+++ b/src/main/java/org/antigen/core/Simulation.java
@@ -258,16 +258,18 @@ public class Simulation {
       globalTotalSamples += summary.getTotalSampled();
     }
 
-    if (globalExperiencedHosts > 0) {
-      csvStream.printf(
-          "%.4f,global,%.6f,%.6f,%.4f,%d%n",
-          year,
-          globalSumAg1 / globalExperiencedHosts,
-          globalSumAg2 / globalExperiencedHosts,
-          1.0 - (double) globalExperiencedHosts / globalTotalSamples,
-          globalExperiencedHosts);
-    } else {
-      csvStream.printf("%.4f,global,NaN,NaN,1.0000,%d%n", year, 0);
+    if (globalTotalSamples > 0) {
+      if (globalExperiencedHosts > 0) {
+        csvStream.printf(
+            "%.4f,global,%.6f,%.6f,%.4f,%d%n",
+            year,
+            globalSumAg1 / globalExperiencedHosts,
+            globalSumAg2 / globalExperiencedHosts,
+            1.0 - (double) globalExperiencedHosts / globalTotalSamples,
+            globalExperiencedHosts);
+      } else {
+        csvStream.printf("%.4f,global,NaN,NaN,1.0000,%d%n", year, 0);
+      }
     }
   }
 

--- a/src/main/java/org/antigen/core/Simulation.java
+++ b/src/main/java/org/antigen/core/Simulation.java
@@ -216,12 +216,52 @@ public class Simulation {
     }
   }
 
-  public void printHostImmuneHistories(PrintStream historyStream) {
-    // For each deme, print the name, and the immune histories of hosts
+  public void printPopulationImmunityCentroids(PrintStream historyStream, boolean writeHeader) {
+    if (writeHeader) {
+      historyStream.println("year,deme,ag1,ag2,naive_fraction,experienced_hosts");
+    }
+    double year = Parameters.day / 365.0;
+    double globalSumAg1 = 0.0;
+    double globalSumAg2 = 0.0;
+    int globalExperiencedHosts = 0;
+    int globalTotalSamples = 0;
+
     for (int i = 0; i < Parameters.demeCount; i++) {
-      HostPopulation hp = demes.get(i);
-      int n = Parameters.hostImmunitySamplesPerDeme[i];
-      hp.printHostImmuneHistories(historyStream, n);
+      int nSamples = Parameters.hostImmunitySamplesPerDeme[i];
+      ImmunitySummary summary = demes.get(i).getPopulationImmunitySummary(nSamples);
+      if (summary.hasValidCentroid()) {
+        historyStream.printf(
+            "%.4f,%s,%.6f,%.6f,%.4f,%d%n",
+            year,
+            Parameters.demeNames[i],
+            summary.getCentroid()[0],
+            summary.getCentroid()[1],
+            summary.getNaiveFraction(),
+            summary.getExperiencedHosts());
+        globalSumAg1 += summary.getCentroid()[0] * summary.getExperiencedHosts();
+        globalSumAg2 += summary.getCentroid()[1] * summary.getExperiencedHosts();
+      } else {
+        historyStream.printf(
+            "%.4f,%s,NaN,NaN,%.4f,%d%n",
+            year,
+            Parameters.demeNames[i],
+            summary.getNaiveFraction(),
+            summary.getExperiencedHosts());
+      }
+      globalExperiencedHosts += summary.getExperiencedHosts();
+      globalTotalSamples += summary.getTotalSampled();
+    }
+
+    if (globalExperiencedHosts > 0) {
+      historyStream.printf(
+          "%.4f,global,%.6f,%.6f,%.4f,%d%n",
+          year,
+          globalSumAg1 / globalExperiencedHosts,
+          globalSumAg2 / globalExperiencedHosts,
+          1.0 - (double) globalExperiencedHosts / globalTotalSamples,
+          globalExperiencedHosts);
+    } else {
+      historyStream.printf("%.4f,global,NaN,NaN,1.0000,%d%n", year, 0);
     }
   }
 
@@ -416,10 +456,11 @@ public class Simulation {
 
       File outDirs = new File(Parameters.outPath);
       outDirs.mkdirs();
-      File historyFile = new File("out.histories");
+      File historyFile = new File("out.histories.csv");
       historyFile.delete();
       historyFile.createNewFile();
       PrintStream historyStream = new PrintStream(historyFile);
+      boolean historiesHeaderWritten = false;
       File seriesFile = new File("out.timeseries");
       seriesFile.delete();
       seriesFile.createNewFile();
@@ -443,9 +484,8 @@ public class Simulation {
         // print immunity if needed
         if (Parameters.sampleHostImmunity
             && Parameters.day % (double) Parameters.printHostImmunityStep < Parameters.deltaT) {
-          // Test print
-          historyStream.printf("date:\t" + "%.2f\n", Parameters.day);
-          printHostImmuneHistories(historyStream);
+          printPopulationImmunityCentroids(historyStream, !historiesHeaderWritten);
+          historiesHeaderWritten = true;
         }
 
         if (getI() == 0) {

--- a/src/main/java/org/antigen/host/Host.java
+++ b/src/main/java/org/antigen/host/Host.java
@@ -124,7 +124,7 @@ public class Host {
   }
 
   // returns the 2D coordinates of the most recent infection, or null if naive
-  public double[] getImmunityCoordinatesCentroid() {
+  public double[] getMostRecentInfectionCoordinates() {
     if (immuneHistory.length == 0) {
       return null;
     }

--- a/src/main/java/org/antigen/host/Host.java
+++ b/src/main/java/org/antigen/host/Host.java
@@ -123,6 +123,14 @@ public class Host {
     return immuneHistory;
   }
 
+  // returns the 2D coordinates of the most recent infection, or null if naive
+  public double[] getImmunityCoordinatesCentroid() {
+    if (immuneHistory.length == 0) {
+      return null;
+    }
+    return immuneHistory[immuneHistory.length - 1].getCoordinates();
+  }
+
   public void printHistoryCoordinates(PrintStream stream) {
     for (Phenotype phenotype : immuneHistory) {
       // get traitA and traitB from phenotype

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -671,9 +671,10 @@ public class HostPopulation {
     List<Host> result = new ArrayList<>(n);
     for (int i = 0; i < n; i++) {
       Host h = null;
-      while (h == null) {
+      while (h == null && getN() > 0) {
         h = getRandomHost();
       }
+      if (h == null) break; // population emptied mid-sampling
       result.add(h);
     }
     return result;

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -666,6 +666,33 @@ public class HostPopulation {
     }
   }
 
+  public ImmunitySummary getPopulationImmunitySummary(int n) {
+    double sumTraitA = 0.0;
+    double sumTraitB = 0.0;
+    int experiencedHosts = 0;
+    int naiveHosts = 0;
+
+    for (int i = 0; i < n; i++) {
+      Host h = getRandomHost();
+      double[] coords = h.getImmunityCoordinatesCentroid();
+      if (coords == null) {
+        naiveHosts++;
+      } else {
+        sumTraitA += coords[0];
+        sumTraitB += coords[1];
+        experiencedHosts++;
+      }
+    }
+
+    double[] avgCentroid =
+        experiencedHosts > 0
+            ? new double[] {sumTraitA / experiencedHosts, sumTraitB / experiencedHosts}
+            : new double[] {Double.NaN, Double.NaN};
+
+    double naiveFraction = (double) naiveHosts / n;
+    return new ImmunitySummary(avgCentroid, naiveFraction, n, experiencedHosts);
+  }
+
   public void printHostImmuneHistories(PrintStream stream, int n) {
     // first, print the contact rate
     stream.printf("contactRate:\t" + "%.4f\n", contactRate);

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -666,14 +666,26 @@ public class HostPopulation {
     }
   }
 
-  public ImmunitySummary getPopulationImmunitySummary(int n) {
+  public List<Host> sampleHosts(int n) {
+    if (n == 0 || getN() == 0) return Collections.emptyList();
+    List<Host> result = new ArrayList<>(n);
+    for (int i = 0; i < n; i++) {
+      Host h = null;
+      while (h == null) {
+        h = getRandomHost();
+      }
+      result.add(h);
+    }
+    return result;
+  }
+
+  public ImmunitySummary getPopulationImmunitySummary(List<Host> hosts) {
     double sumTraitA = 0.0;
     double sumTraitB = 0.0;
     int experiencedHosts = 0;
     int naiveHosts = 0;
 
-    for (int i = 0; i < n; i++) {
-      Host h = getRandomHost();
+    for (Host h : hosts) {
       double[] coords = h.getImmunityCoordinatesCentroid();
       if (coords == null) {
         naiveHosts++;
@@ -684,24 +696,29 @@ public class HostPopulation {
       }
     }
 
+    int n = hosts.size();
     double[] avgCentroid =
         experiencedHosts > 0
             ? new double[] {sumTraitA / experiencedHosts, sumTraitB / experiencedHosts}
             : new double[] {Double.NaN, Double.NaN};
-
-    double naiveFraction = (double) naiveHosts / n;
+    double naiveFraction = n > 0 ? (double) naiveHosts / n : Double.NaN;
     return new ImmunitySummary(avgCentroid, naiveFraction, n, experiencedHosts);
   }
 
-  public void printHostImmuneHistories(PrintStream stream, int n) {
-    // first, print the contact rate
-    stream.printf("contactRate:\t" + "%.4f\n", contactRate);
-    // grab n random hosts and print their immune histories
-    for (int i = 0; i < n; i++) {
-      Host h = getRandomHost();
+  public ImmunitySummary getPopulationImmunitySummary(int n) {
+    return getPopulationImmunitySummary(sampleHosts(n));
+  }
+
+  public void printHostImmuneHistories(PrintStream stream, List<Host> hosts) {
+    stream.printf("contactRate:\t%.4f\n", contactRate);
+    for (Host h : hosts) {
       stream.print(name + ":");
       h.printHistoryCoordinates(stream);
     }
+  }
+
+  public void printHostImmuneHistories(PrintStream stream, int n) {
+    printHostImmuneHistories(stream, sampleHosts(n));
   }
 
   public void printHostPopulation(PrintStream stream) {

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -686,7 +686,7 @@ public class HostPopulation {
     int naiveHosts = 0;
 
     for (Host h : hosts) {
-      double[] coords = h.getImmunityCoordinatesCentroid();
+      double[] coords = h.getMostRecentInfectionCoordinates();
       if (coords == null) {
         naiveHosts++;
       } else {

--- a/src/main/java/org/antigen/host/ImmunitySummary.java
+++ b/src/main/java/org/antigen/host/ImmunitySummary.java
@@ -16,7 +16,7 @@ public class ImmunitySummary {
   }
 
   public double[] getCentroid() {
-    return centroid;
+    return centroid.clone();
   }
 
   public double getNaiveFraction() {

--- a/src/main/java/org/antigen/host/ImmunitySummary.java
+++ b/src/main/java/org/antigen/host/ImmunitySummary.java
@@ -1,0 +1,37 @@
+package org.antigen.host;
+
+public class ImmunitySummary {
+
+  private final double[] centroid;
+  private final double naiveFraction;
+  private final int totalSampled;
+  private final int experiencedHosts;
+
+  public ImmunitySummary(
+      double[] centroid, double naiveFraction, int totalSampled, int experiencedHosts) {
+    this.centroid = centroid;
+    this.naiveFraction = naiveFraction;
+    this.totalSampled = totalSampled;
+    this.experiencedHosts = experiencedHosts;
+  }
+
+  public double[] getCentroid() {
+    return centroid;
+  }
+
+  public double getNaiveFraction() {
+    return naiveFraction;
+  }
+
+  public int getTotalSampled() {
+    return totalSampled;
+  }
+
+  public int getExperiencedHosts() {
+    return experiencedHosts;
+  }
+
+  public boolean hasValidCentroid() {
+    return !Double.isNaN(centroid[0]) && !Double.isNaN(centroid[1]);
+  }
+}

--- a/src/main/java/org/antigen/phenotype/GeometricPhenotype.java
+++ b/src/main/java/org/antigen/phenotype/GeometricPhenotype.java
@@ -109,6 +109,10 @@ public class GeometricPhenotype implements Phenotype {
     return mutP;
   }
 
+  public double[] getCoordinates() {
+    return new double[] {getTraitA(), getTraitB()};
+  }
+
   public String toString() {
     String fullString = String.format("%.4f,%.4f", traitA, traitB);
     return fullString;

--- a/src/main/java/org/antigen/phenotype/GeometricPhenotype10D.java
+++ b/src/main/java/org/antigen/phenotype/GeometricPhenotype10D.java
@@ -107,6 +107,10 @@ public class GeometricPhenotype10D implements Phenotype {
     return mutP;
   }
 
+  public double[] getCoordinates() {
+    return new double[] {traits[0], traits[1]};
+  }
+
   public String toString() {
     //		String fullString = String.format("%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f",
     // traits);

--- a/src/main/java/org/antigen/phenotype/GeometricPhenotype3D.java
+++ b/src/main/java/org/antigen/phenotype/GeometricPhenotype3D.java
@@ -107,6 +107,10 @@ public class GeometricPhenotype3D implements Phenotype {
     return mutP;
   }
 
+  public double[] getCoordinates() {
+    return new double[] {traitA, traitB};
+  }
+
   public String toString() {
     String fullString = String.format("%.4f,%.4f,%.4f", traitA, traitB, traitC);
     return fullString;

--- a/src/main/java/org/antigen/phenotype/GeometricPhenotype3D.java
+++ b/src/main/java/org/antigen/phenotype/GeometricPhenotype3D.java
@@ -108,7 +108,7 @@ public class GeometricPhenotype3D implements Phenotype {
   }
 
   public double[] getCoordinates() {
-    return new double[] {traitA, traitB};
+    return new double[] {getTraitA(), getTraitB()};
   }
 
   public String toString() {

--- a/src/main/java/org/antigen/phenotype/Phenotype.java
+++ b/src/main/java/org/antigen/phenotype/Phenotype.java
@@ -15,6 +15,9 @@ public interface Phenotype {
   // compare phenotypes and report antigenic distance
   double distance(Phenotype p);
 
+  // 2D antigenic coordinates as {traitA, traitB}
+  double[] getCoordinates();
+
   // this is used in output, should be a short string form
   // 2D: 0.5,0.6
   // sequence: "ATGCGCC"

--- a/src/test/java/org/antigen/host/TestHostMostRecentInfection.java
+++ b/src/test/java/org/antigen/host/TestHostMostRecentInfection.java
@@ -20,7 +20,7 @@ public class TestHostMostRecentInfection {
   @Test
   public void testNaiveHostCentroid() {
     Host host = new Host();
-    double[] centroid = host.getImmunityCoordinatesCentroid();
+    double[] centroid = host.getMostRecentInfectionCoordinates();
     assertNull("Naive host should return null centroid", centroid);
   }
 
@@ -30,7 +30,7 @@ public class TestHostMostRecentInfection {
     GeometricPhenotype phenotype = new GeometricPhenotype(2.0, 3.0);
     host.addToHistory(phenotype);
 
-    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    double[] mostRecent = host.getMostRecentInfectionCoordinates();
     assertNotNull(mostRecent);
     assertEquals(2.0, mostRecent[0], 1e-10);
     assertEquals(3.0, mostRecent[1], 1e-10);
@@ -42,7 +42,7 @@ public class TestHostMostRecentInfection {
     host.addToHistory(new GeometricPhenotype(1.0, 2.0));
     host.addToHistory(new GeometricPhenotype(3.0, 4.0));
 
-    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    double[] mostRecent = host.getMostRecentInfectionCoordinates();
     assertNotNull(mostRecent);
     assertEquals(3.0, mostRecent[0], 1e-10);
     assertEquals(4.0, mostRecent[1], 1e-10);
@@ -54,7 +54,7 @@ public class TestHostMostRecentInfection {
     GeometricSeqPhenotype phenotype = new GeometricSeqPhenotype(5.0, 7.0);
     host.addToHistory(phenotype);
 
-    double[] centroid = host.getImmunityCoordinatesCentroid();
+    double[] centroid = host.getMostRecentInfectionCoordinates();
     assertNotNull(centroid);
     assertEquals(5.0, centroid[0], 1e-10);
     assertEquals(7.0, centroid[1], 1e-10);
@@ -66,7 +66,7 @@ public class TestHostMostRecentInfection {
     host.addToHistory(new GeometricPhenotype(2.0, 4.0));
     host.addToHistory(new GeometricSeqPhenotype(6.0, 8.0));
 
-    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    double[] mostRecent = host.getMostRecentInfectionCoordinates();
     assertNotNull(mostRecent);
     assertEquals(6.0, mostRecent[0], 1e-10);
     assertEquals(8.0, mostRecent[1], 1e-10);
@@ -79,7 +79,7 @@ public class TestHostMostRecentInfection {
     host.addToHistory(new GeometricPhenotype(5.0, 5.0));
     host.addToHistory(new GeometricPhenotype(9.0, 9.0));
 
-    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    double[] mostRecent = host.getMostRecentInfectionCoordinates();
     assertNotNull(mostRecent);
     assertEquals(9.0, mostRecent[0], 1e-10);
     assertEquals(9.0, mostRecent[1], 1e-10);

--- a/src/test/java/org/antigen/host/TestHostMostRecentInfection.java
+++ b/src/test/java/org/antigen/host/TestHostMostRecentInfection.java
@@ -1,0 +1,87 @@
+package org.antigen.host;
+
+import static org.junit.Assert.*;
+
+import org.antigen.core.Parameters;
+import org.antigen.phenotype.GeometricPhenotype;
+import org.antigen.phenotype.GeometricSeqPhenotype;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestHostMostRecentInfection {
+
+  @Before
+  public void setUp() {
+    Parameters.load();
+    Parameters.initialize();
+    Parameters.initialPrR = 0.0;
+  }
+
+  @Test
+  public void testNaiveHostCentroid() {
+    Host host = new Host();
+    double[] centroid = host.getImmunityCoordinatesCentroid();
+    assertNull("Naive host should return null centroid", centroid);
+  }
+
+  @Test
+  public void testSingleInfectionMostRecent() {
+    Host host = new Host();
+    GeometricPhenotype phenotype = new GeometricPhenotype(2.0, 3.0);
+    host.addToHistory(phenotype);
+
+    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    assertNotNull(mostRecent);
+    assertEquals(2.0, mostRecent[0], 1e-10);
+    assertEquals(3.0, mostRecent[1], 1e-10);
+  }
+
+  @Test
+  public void testMultipleInfectionsMostRecent() {
+    Host host = new Host();
+    host.addToHistory(new GeometricPhenotype(1.0, 2.0));
+    host.addToHistory(new GeometricPhenotype(3.0, 4.0));
+
+    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    assertNotNull(mostRecent);
+    assertEquals(3.0, mostRecent[0], 1e-10);
+    assertEquals(4.0, mostRecent[1], 1e-10);
+  }
+
+  @Test
+  public void testGeometricSeqPhenotypeCentroid() {
+    Host host = new Host();
+    GeometricSeqPhenotype phenotype = new GeometricSeqPhenotype(5.0, 7.0);
+    host.addToHistory(phenotype);
+
+    double[] centroid = host.getImmunityCoordinatesCentroid();
+    assertNotNull(centroid);
+    assertEquals(5.0, centroid[0], 1e-10);
+    assertEquals(7.0, centroid[1], 1e-10);
+  }
+
+  @Test
+  public void testMixedPhenotypesMostRecent() {
+    Host host = new Host();
+    host.addToHistory(new GeometricPhenotype(2.0, 4.0));
+    host.addToHistory(new GeometricSeqPhenotype(6.0, 8.0));
+
+    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    assertNotNull(mostRecent);
+    assertEquals(6.0, mostRecent[0], 1e-10);
+    assertEquals(8.0, mostRecent[1], 1e-10);
+  }
+
+  @Test
+  public void testMostRecentOrderMatters() {
+    Host host = new Host();
+    host.addToHistory(new GeometricPhenotype(1.0, 1.0));
+    host.addToHistory(new GeometricPhenotype(5.0, 5.0));
+    host.addToHistory(new GeometricPhenotype(9.0, 9.0));
+
+    double[] mostRecent = host.getImmunityCoordinatesCentroid();
+    assertNotNull(mostRecent);
+    assertEquals(9.0, mostRecent[0], 1e-10);
+    assertEquals(9.0, mostRecent[1], 1e-10);
+  }
+}

--- a/src/test/java/org/antigen/host/TestHostPopulationSummary.java
+++ b/src/test/java/org/antigen/host/TestHostPopulationSummary.java
@@ -2,6 +2,8 @@ package org.antigen.host;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.List;
 import org.antigen.core.Parameters;
 import org.antigen.phenotype.GeometricPhenotype;
 import org.junit.Before;
@@ -38,22 +40,40 @@ public class TestHostPopulationSummary {
   }
 
   @Test
-  public void testMixedPopulation() {
-    for (int i = 0; i < 5; i++) {
-      Host host = population.getRandomHost();
-      host.addToHistory(new GeometricPhenotype(i * 1.0, i * 2.0));
-    }
+  public void testExactCentroid() {
+    Host h1 = new Host();
+    Host h2 = new Host();
+    Host h3 = new Host();
+    h1.addToHistory(new GeometricPhenotype(0.0, 0.0));
+    h2.addToHistory(new GeometricPhenotype(2.0, 4.0));
+    h3.addToHistory(new GeometricPhenotype(4.0, 8.0));
 
-    ImmunitySummary summary = population.getPopulationImmunitySummary(20);
+    List<Host> sampled = Arrays.asList(h1, h2, h3);
+    ImmunitySummary summary = population.getPopulationImmunitySummary(sampled);
 
-    assertTrue(summary.getNaiveFraction() > 0.0);
-    assertTrue(summary.getNaiveFraction() < 1.0);
-    assertTrue(summary.getExperiencedHosts() > 0);
-    assertEquals(20, summary.getTotalSampled());
-    if (summary.hasValidCentroid()) {
-      assertFalse(Double.isNaN(summary.getCentroid()[0]));
-      assertFalse(Double.isNaN(summary.getCentroid()[1]));
-    }
+    assertEquals(0.0, summary.getNaiveFraction(), 1e-10);
+    assertEquals(3, summary.getExperiencedHosts());
+    assertTrue(summary.hasValidCentroid());
+    assertEquals(2.0, summary.getCentroid()[0], 1e-10); // (0+2+4)/3
+    assertEquals(4.0, summary.getCentroid()[1], 1e-10); // (0+4+8)/3
+  }
+
+  @Test
+  public void testExactCentroidWithNaiveHosts() {
+    Host h1 = new Host();
+    Host h2 = new Host();
+    Host h3 = new Host(); // naive
+    h1.addToHistory(new GeometricPhenotype(1.0, 2.0));
+    h2.addToHistory(new GeometricPhenotype(3.0, 6.0));
+
+    List<Host> sampled = Arrays.asList(h1, h2, h3);
+    ImmunitySummary summary = population.getPopulationImmunitySummary(sampled);
+
+    assertEquals(1.0 / 3.0, summary.getNaiveFraction(), 1e-10);
+    assertEquals(2, summary.getExperiencedHosts());
+    assertTrue(summary.hasValidCentroid());
+    assertEquals(2.0, summary.getCentroid()[0], 1e-10); // (1+3)/2
+    assertEquals(4.0, summary.getCentroid()[1], 1e-10); // (2+6)/2
   }
 
   @Test
@@ -76,5 +96,14 @@ public class TestHostPopulationSummary {
     assertFalse(summary.hasValidCentroid());
     assertTrue(Double.isNaN(summary.getCentroid()[0]));
     assertTrue(Double.isNaN(summary.getCentroid()[1]));
+  }
+
+  @Test
+  public void testEmptySampleList() {
+    ImmunitySummary summary = population.getPopulationImmunitySummary(List.of());
+
+    assertEquals(0, summary.getTotalSampled());
+    assertEquals(0, summary.getExperiencedHosts());
+    assertTrue(Double.isNaN(summary.getCentroid()[0]));
   }
 }

--- a/src/test/java/org/antigen/host/TestHostPopulationSummary.java
+++ b/src/test/java/org/antigen/host/TestHostPopulationSummary.java
@@ -1,0 +1,80 @@
+package org.antigen.host;
+
+import static org.junit.Assert.*;
+
+import org.antigen.core.Parameters;
+import org.antigen.phenotype.GeometricPhenotype;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestHostPopulationSummary {
+
+  private HostPopulation population;
+
+  @Before
+  public void setUp() {
+    Parameters.load();
+    Parameters.initialize();
+    Parameters.demeCount = 1;
+    Parameters.demeNames = new String[] {"test"};
+    Parameters.initialNs = new int[] {100};
+    Parameters.initialPrR = 0.0;
+    Parameters.swapDemography = false;
+    Parameters.transcendental = false;
+    Parameters.waning = false;
+    population = new HostPopulation(0);
+  }
+
+  @Test
+  public void testAllNaivePopulation() {
+    ImmunitySummary summary = population.getPopulationImmunitySummary(10);
+
+    assertEquals(1.0, summary.getNaiveFraction(), 1e-10);
+    assertEquals(0, summary.getExperiencedHosts());
+    assertEquals(10, summary.getTotalSampled());
+    assertFalse(summary.hasValidCentroid());
+    assertTrue(Double.isNaN(summary.getCentroid()[0]));
+    assertTrue(Double.isNaN(summary.getCentroid()[1]));
+  }
+
+  @Test
+  public void testMixedPopulation() {
+    for (int i = 0; i < 5; i++) {
+      Host host = population.getRandomHost();
+      host.addToHistory(new GeometricPhenotype(i * 1.0, i * 2.0));
+    }
+
+    ImmunitySummary summary = population.getPopulationImmunitySummary(20);
+
+    assertTrue(summary.getNaiveFraction() > 0.0);
+    assertTrue(summary.getNaiveFraction() < 1.0);
+    assertTrue(summary.getExperiencedHosts() > 0);
+    assertEquals(20, summary.getTotalSampled());
+    if (summary.hasValidCentroid()) {
+      assertFalse(Double.isNaN(summary.getCentroid()[0]));
+      assertFalse(Double.isNaN(summary.getCentroid()[1]));
+    }
+  }
+
+  @Test
+  public void testImmunitySummaryProperties() {
+    ImmunitySummary summary = new ImmunitySummary(new double[] {1.0, 2.0}, 0.3, 100, 70);
+
+    assertEquals(1.0, summary.getCentroid()[0], 1e-10);
+    assertEquals(2.0, summary.getCentroid()[1], 1e-10);
+    assertEquals(0.3, summary.getNaiveFraction(), 1e-10);
+    assertEquals(100, summary.getTotalSampled());
+    assertEquals(70, summary.getExperiencedHosts());
+    assertTrue(summary.hasValidCentroid());
+  }
+
+  @Test
+  public void testNaNHandling() {
+    ImmunitySummary summary =
+        new ImmunitySummary(new double[] {Double.NaN, Double.NaN}, 1.0, 50, 0);
+
+    assertFalse(summary.hasValidCentroid());
+    assertTrue(Double.isNaN(summary.getCentroid()[0]));
+    assertTrue(Double.isNaN(summary.getCentroid()[1]));
+  }
+}


### PR DESCRIPTION
Closes #50

## Summary
Restores `out.histories.csv` from orphaned commit d21b86d into the current Maven codebase. The output records population immunity centroids (most-recent-infection coordinates averaged over sampled hosts) per deme plus a global row, on each `printHostImmunityStep` interval.

Key changes:
- `Phenotype` interface gains `getCoordinates()` — eliminates `instanceof` cast antipattern
- `ImmunitySummary` data class holds centroid, naive fraction, and sample counts
- `Host.getImmunityCoordinatesCentroid()` returns most-recent-infection coords or null for naive
- `HostPopulation.getPopulationImmunitySummary(n)` averages over n sampled hosts
- `Simulation` writes `out.histories.csv` with header `year,deme,ag1,ag2,naive_fraction,experienced_hosts`

## Assumptions & Decisions
- `GeometricPhenotype.getCoordinates()` calls `getTraitA()`/`getTraitB()` (not direct field access) so subclass overrides in `GeometricSeqPhenotype` dispatch correctly.
- 3D and 10D phenotypes return their first two traits as 2D coordinates (centroid output is only meaningful for geometric/geometricSeq runs).
- CSV header is written once on the first sampling call, not tied to `day == 0` (avoids assuming burnin=0 edge cases).