### PR TITLE
Reformat out.histories to long-format CSV; drop contactRate

### DIFF
--- a/docs/user-guide/output-analysis.md
+++ b/docs/user-guide/output-analysis.md
@@ -13,7 +13,7 @@ antigen-prime generates several output files that capture different aspects of t
 | `out.fasta`      | Virus sequences           | Sequence analysis, alignment, molecular evolution (GeometricSeq only)       |
 | `out.tree`       | Newick tree format        | Tree visualization in standard phylogenetic software                        |
 | `out.immunity`   | Final immunity landscape  | Population-level immunity snapshot at simulation end (optional)             |
-| `out.histories`  | Host immune histories     | Raw per-host immune coordinates for sampled hosts at each sampling interval (optional) |
+| `out.histories`  | Host immune histories     | Long-format CSV of per-host infection coordinates for sampled hosts at each sampling interval (optional) |
 | `out.histories.csv` | Population immunity centroids | Per-deme average antigenic position of most-recent infections (optional) |
 
 ## Core Output Files
@@ -145,7 +145,18 @@ Header format: `>seq{number}|{birth_time}|{fitness}`
 
 **Purpose:** Both files are written on the same schedule (`printHostImmunityStep`) from the **same sampled hosts**, so they form a coherent pair — the raw histories are the exact dataset used to compute the centroids.
 
-**`out.histories`** — raw per-host coordinates: for each sampling interval, prints the contact rate and the full immune history coordinates of every sampled host, grouped by deme.
+**`out.histories`** — long-format CSV of per-host infection coordinates. One row per (host, infection) pair; naive hosts produce no rows but are counted in `naive_fraction`. Columns:
+
+```
+year,deme,host_id,infection_index,ag1,ag2,naive_fraction
+```
+
+- `year`: burn-in-adjusted snapshot year
+- `deme`: deme name
+- `host_id`: sequential integer within each snapshot/deme block (not persistent across snapshots)
+- `infection_index`: position in the host's immune history (0 = oldest)
+- `ag1`, `ag2`: antigenic coordinates of that infection
+- `naive_fraction`: fraction of sampled hosts with empty immune history for this snapshot/deme (repeated per row as snapshot-level metadata)
 
 **`out.histories.csv`** — per-deme and global centroids: CSV with columns `year,deme,ag1,ag2,naive_fraction,experienced_hosts`. One row per deme plus a `global` aggregate row. See the [immunity centroids guide](immunity-centroids.md) for full details.
 

--- a/src/main/java/org/antigen/core/Simulation.java
+++ b/src/main/java/org/antigen/core/Simulation.java
@@ -471,7 +471,7 @@ public class Simulation {
       historyCsvFile.delete();
       historyCsvFile.createNewFile();
       PrintStream historyCsvStream = new PrintStream(historyCsvFile);
-      File historyRawFile = new File("out.histories");
+      File historyRawFile = new File("out.histories.raw.csv");
       historyRawFile.delete();
       historyRawFile.createNewFile();
       PrintStream historyRawStream = new PrintStream(historyRawFile);

--- a/src/main/java/org/antigen/core/Simulation.java
+++ b/src/main/java/org/antigen/core/Simulation.java
@@ -234,7 +234,8 @@ public class Simulation {
       HostPopulation hp = demes.get(i);
       List<Host> sampled = hp.sampleHosts(nSamples);
       ImmunitySummary summary = hp.getPopulationImmunitySummary(sampled);
-      hp.printHostImmuneHistoriesCsv(rawStream, sampled, year, summary.getNaiveFraction(), rawHeaderNeeded);
+      hp.printHostImmuneHistoriesCsv(
+          rawStream, sampled, year, summary.getNaiveFraction(), rawHeaderNeeded);
       rawHeaderNeeded = false;
 
       if (summary.hasValidCentroid()) {

--- a/src/main/java/org/antigen/core/Simulation.java
+++ b/src/main/java/org/antigen/core/Simulation.java
@@ -227,13 +227,15 @@ public class Simulation {
     int globalExperiencedHosts = 0;
     int globalTotalSamples = 0;
 
+    boolean rawHeaderNeeded = writeHeader;
     for (int i = 0; i < Parameters.demeCount; i++) {
       int nSamples = Parameters.hostImmunitySamplesPerDeme[i];
       if (nSamples == 0) continue;
       HostPopulation hp = demes.get(i);
       List<Host> sampled = hp.sampleHosts(nSamples);
       ImmunitySummary summary = hp.getPopulationImmunitySummary(sampled);
-      hp.printHostImmuneHistories(rawStream, sampled);
+      hp.printHostImmuneHistoriesCsv(rawStream, sampled, year, summary.getNaiveFraction(), rawHeaderNeeded);
+      rawHeaderNeeded = false;
 
       if (summary.hasValidCentroid()) {
         csvStream.printf(

--- a/src/main/java/org/antigen/host/Host.java
+++ b/src/main/java/org/antigen/host/Host.java
@@ -131,17 +131,6 @@ public class Host {
     return immuneHistory[immuneHistory.length - 1].getCoordinates();
   }
 
-  public void printHistoryCoordinates(PrintStream stream) {
-    for (Phenotype phenotype : immuneHistory) {
-      // get traitA and traitB from phenotype
-      String[] p = phenotype.toString().split(",");
-      String traitA = p[1];
-      String traitB = p[2];
-      stream.print("(" + traitA + "," + traitB + ")");
-    }
-    stream.println();
-  }
-
   public void printInfection(PrintStream stream) {
     if (infection != null) {
       stream.print(infection.getPhenotype());

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -711,9 +711,9 @@ public class HostPopulation {
   /**
    * Writes per-infection rows to {@code stream} in long-format CSV.
    *
-   * <p>One row is emitted per (host, infection) pair. Naive hosts produce no rows but still
-   * consume a sequential {@code host_id}. {@code naive_fraction} is repeated on every row as
-   * snapshot-level metadata.
+   * <p>One row is emitted per (host, infection) pair. Naive hosts produce no rows but still consume
+   * a sequential {@code host_id}. {@code naive_fraction} is repeated on every row as snapshot-level
+   * metadata.
    *
    * <p>Format: {@code year,deme,host_id,infection_index,ag1,ag2,naive_fraction}
    *
@@ -739,8 +739,13 @@ public class HostPopulation {
         double[] coords = history[i].getCoordinates();
         if (coords.length < 2) {
           throw new IllegalStateException(
-              "Phenotype at host " + hostId + " infection " + i
-              + " returned fewer than 2 coordinates (got " + coords.length + ")");
+              "Phenotype at host "
+                  + hostId
+                  + " infection "
+                  + i
+                  + " returned fewer than 2 coordinates (got "
+                  + coords.length
+                  + ")");
         }
         stream.printf(
             "%.4f,%s,%d,%d,%.6f,%.6f,%.4f%n",

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -710,16 +710,41 @@ public class HostPopulation {
     return getPopulationImmunitySummary(sampleHosts(n));
   }
 
-  public void printHostImmuneHistories(PrintStream stream, List<Host> hosts) {
-    stream.printf("contactRate:\t%.4f\n", contactRate);
-    for (Host h : hosts) {
-      stream.print(name + ":");
-      h.printHistoryCoordinates(stream);
+  /**
+   * Writes per-infection rows to {@code stream} in long-format CSV.
+   *
+   * <p>One row is emitted per (host, infection) pair. Naive hosts produce no rows but still
+   * consume a sequential {@code host_id}. {@code naive_fraction} is repeated on every row as
+   * snapshot-level metadata.
+   *
+   * <p>Format: {@code year,deme,host_id,infection_index,ag1,ag2,naive_fraction}
+   *
+   * @param stream output stream
+   * @param hosts sampled hosts for this snapshot/deme
+   * @param year burn-in-adjusted simulation year
+   * @param naiveFraction fraction of sampled hosts with empty immune history
+   * @param writeHeader if true, emit the CSV header line before data rows
+   */
+  public void printHostImmuneHistoriesCsv(
+      PrintStream stream,
+      List<Host> hosts,
+      double year,
+      double naiveFraction,
+      boolean writeHeader) {
+    if (writeHeader) {
+      stream.println("year,deme,host_id,infection_index,ag1,ag2,naive_fraction");
     }
-  }
-
-  public void printHostImmuneHistories(PrintStream stream, int n) {
-    printHostImmuneHistories(stream, sampleHosts(n));
+    int hostId = 0;
+    for (Host h : hosts) {
+      Phenotype[] history = h.getHistory();
+      for (int i = 0; i < history.length; i++) {
+        double[] coords = history[i].getCoordinates();
+        stream.printf(
+            "%.4f,%s,%d,%d,%.6f,%.6f,%.4f%n",
+            year, name, hostId, i, coords[0], coords[1], naiveFraction);
+      }
+      hostId++;
+    }
   }
 
   public void printHostPopulation(PrintStream stream) {

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -717,6 +717,9 @@ public class HostPopulation {
    *
    * <p>Format: {@code year,deme,host_id,infection_index,ag1,ag2,naive_fraction}
    *
+   * <p>Assumes {@code getCoordinates()} returns at least 2 elements; only ag1/ag2 are written
+   * regardless of phenotype dimensionality.
+   *
    * @param stream output stream
    * @param hosts sampled hosts for this snapshot/deme
    * @param year burn-in-adjusted simulation year

--- a/src/main/java/org/antigen/host/HostPopulation.java
+++ b/src/main/java/org/antigen/host/HostPopulation.java
@@ -29,7 +29,6 @@ public class HostPopulation {
 
   private int newContacts;
   private int newRecoveries;
-  private double contactRate;
 
   // construct population, using Virus v as initial infection
   public HostPopulation(int d) {
@@ -351,7 +350,6 @@ public class HostPopulation {
     // each infected makes I->S contacts on a per-day rate of beta * S/N
     double totalContactRate =
         getI() * getPrS() * Parameters.beta * Parameters.getSeasonality(deme) * Parameters.deltaT;
-    contactRate = totalContactRate;
     newContacts = Random.nextPoisson(totalContactRate);
   }
 
@@ -739,6 +737,11 @@ public class HostPopulation {
       Phenotype[] history = h.getHistory();
       for (int i = 0; i < history.length; i++) {
         double[] coords = history[i].getCoordinates();
+        if (coords.length < 2) {
+          throw new IllegalStateException(
+              "Phenotype at host " + hostId + " infection " + i
+              + " returned fewer than 2 coordinates (got " + coords.length + ")");
+        }
         stream.printf(
             "%.4f,%s,%d,%d,%.6f,%.6f,%.4f%n",
             year, name, hostId, i, coords[0], coords[1], naiveFraction);

--- a/src/test/java/org/antigen/host/TestHostImmuneHistoriesCsv.java
+++ b/src/test/java/org/antigen/host/TestHostImmuneHistoriesCsv.java
@@ -162,11 +162,25 @@ public class TestHostImmuneHistoriesCsv {
     // A phenotype returning fewer than 2 coordinates must fail loudly, not silently truncate.
     Phenotype zeroD =
         new Phenotype() {
-          public double riskOfInfection(Phenotype[] h) { return 0; }
-          public Phenotype mutate() { return this; }
-          public double distance(Phenotype p) { return 0; }
-          public double[] getCoordinates() { return new double[0]; }
-          public String toString() { return ""; }
+          public double riskOfInfection(Phenotype[] h) {
+            return 0;
+          }
+
+          public Phenotype mutate() {
+            return this;
+          }
+
+          public double distance(Phenotype p) {
+            return 0;
+          }
+
+          public double[] getCoordinates() {
+            return new double[0];
+          }
+
+          public String toString() {
+            return "";
+          }
         };
     Host h = new Host();
     h.addToHistory(zeroD);

--- a/src/test/java/org/antigen/host/TestHostImmuneHistoriesCsv.java
+++ b/src/test/java/org/antigen/host/TestHostImmuneHistoriesCsv.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.antigen.core.Parameters;
 import org.antigen.phenotype.GeometricPhenotype;
+import org.antigen.phenotype.Phenotype;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -154,5 +155,22 @@ public class TestHostImmuneHistoriesCsv {
     assertEquals("0", lines[0].split(",")[2]);
     assertEquals("1", lines[1].split(",")[2]);
     assertEquals("2", lines[2].split(",")[2]);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testBoundsGuardThrowsOnSubDimensionalPhenotype() {
+    // A phenotype returning fewer than 2 coordinates must fail loudly, not silently truncate.
+    Phenotype zeroD =
+        new Phenotype() {
+          public double riskOfInfection(Phenotype[] h) { return 0; }
+          public Phenotype mutate() { return this; }
+          public double distance(Phenotype p) { return 0; }
+          public double[] getCoordinates() { return new double[0]; }
+          public String toString() { return ""; }
+        };
+    Host h = new Host();
+    h.addToHistory(zeroD);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    population.printHostImmuneHistoriesCsv(new PrintStream(baos), List.of(h), 5.0, 0.0, false);
   }
 }

--- a/src/test/java/org/antigen/host/TestHostImmuneHistoriesCsv.java
+++ b/src/test/java/org/antigen/host/TestHostImmuneHistoriesCsv.java
@@ -1,0 +1,158 @@
+package org.antigen.host;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+import org.antigen.core.Parameters;
+import org.antigen.phenotype.GeometricPhenotype;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for HostPopulation.printHostImmuneHistoriesCsv. */
+public class TestHostImmuneHistoriesCsv {
+
+  private HostPopulation population;
+  private static final String HEADER = "year,deme,host_id,infection_index,ag1,ag2,naive_fraction";
+
+  @Before
+  public void setUp() {
+    Parameters.load();
+    Parameters.initialize();
+    Parameters.demeCount = 1;
+    Parameters.demeNames = new String[] {"north"};
+    Parameters.initialNs = new int[] {100};
+    Parameters.initialPrR = 0.0;
+    Parameters.swapDemography = false;
+    Parameters.transcendental = false;
+    Parameters.waning = false;
+    population = new HostPopulation(0);
+  }
+
+  private String capture(List<Host> hosts, double year, double naiveFraction, boolean writeHeader) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(baos);
+    population.printHostImmuneHistoriesCsv(ps, hosts, year, naiveFraction, writeHeader);
+    ps.flush();
+    return baos.toString();
+  }
+
+  @Test
+  public void testHeaderWrittenWhenRequested() {
+    List<Host> hosts = List.of();
+    String out = capture(hosts, 5.0, 1.0, true);
+    assertTrue("header must be first line", out.startsWith(HEADER));
+  }
+
+  @Test
+  public void testHeaderOmittedWhenNotRequested() {
+    List<Host> hosts = List.of();
+    String out = capture(hosts, 5.0, 1.0, false);
+    assertFalse("no header when writeHeader=false", out.contains(HEADER));
+    assertEquals("output must be empty", "", out.trim());
+  }
+
+  @Test
+  public void testAllNaiveProducesNoDataRows() {
+    Host h1 = new Host();
+    Host h2 = new Host();
+    List<Host> hosts = Arrays.asList(h1, h2);
+    String out = capture(hosts, 5.0, 1.0, true);
+    String[] lines = out.trim().split("\\r?\\n");
+    // only the header line
+    assertEquals(1, lines.length);
+    assertEquals(HEADER, lines[0]);
+  }
+
+  @Test
+  public void testSingleExperiencedHostSingleInfection() {
+    Host h = new Host();
+    h.addToHistory(new GeometricPhenotype(1.23, 4.56));
+    List<Host> hosts = List.of(h);
+    String out = capture(hosts, 5.0, 0.12, true);
+    String[] lines = out.trim().split("\\r?\\n");
+    assertEquals(2, lines.length); // header + 1 data row
+    String row = lines[1];
+    String[] cols = row.split(",");
+    assertEquals(7, cols.length);
+    assertEquals("5.0000", cols[0]);
+    assertEquals("north", cols[1]);
+    assertEquals("0", cols[2]); // host_id
+    assertEquals("0", cols[3]); // infection_index
+    assertEquals(1.23, Double.parseDouble(cols[4]), 1e-5);
+    assertEquals(4.56, Double.parseDouble(cols[5]), 1e-5);
+    assertEquals(0.12, Double.parseDouble(cols[6]), 1e-4);
+  }
+
+  @Test
+  public void testSingleExperiencedHostMultipleInfections() {
+    Host h = new Host();
+    h.addToHistory(new GeometricPhenotype(1.0, 2.0));
+    h.addToHistory(new GeometricPhenotype(3.0, 4.0));
+    List<Host> hosts = List.of(h);
+    String out = capture(hosts, 6.0, 0.0, true);
+    String[] lines = out.trim().split("\\r?\\n");
+    assertEquals(3, lines.length); // header + 2 rows
+    // infection_index 0
+    assertEquals("0", lines[1].split(",")[3]);
+    assertEquals(1.0, Double.parseDouble(lines[1].split(",")[4]), 1e-5);
+    // infection_index 1
+    assertEquals("1", lines[2].split(",")[3]);
+    assertEquals(3.0, Double.parseDouble(lines[2].split(",")[4]), 1e-5);
+  }
+
+  @Test
+  public void testMixedNaiveAndExperiencedHostIds() {
+    Host naive = new Host();
+    Host experienced = new Host();
+    experienced.addToHistory(new GeometricPhenotype(2.0, 5.0));
+    // naive at index 0, experienced at index 1 → host_id for experienced row must be 1
+    List<Host> hosts = Arrays.asList(naive, experienced);
+    String out = capture(hosts, 5.0, 0.5, true);
+    String[] lines = out.trim().split("\\r?\\n");
+    assertEquals(2, lines.length); // header + 1 row for experienced host
+    assertEquals("1", lines[1].split(",")[2]); // host_id = 1 (naive was 0)
+  }
+
+  @Test
+  public void testNaiveFractionRepeatedPerRow() {
+    Host h1 = new Host();
+    Host h2 = new Host();
+    h1.addToHistory(new GeometricPhenotype(0.0, 0.0));
+    h2.addToHistory(new GeometricPhenotype(1.0, 1.0));
+    List<Host> hosts = Arrays.asList(h1, h2);
+    double naiveFraction = 0.333;
+    String out = capture(hosts, 7.0, naiveFraction, true);
+    String[] lines = out.trim().split("\\r?\\n");
+    assertEquals(3, lines.length);
+    assertEquals(naiveFraction, Double.parseDouble(lines[1].split(",")[6]), 1e-4);
+    assertEquals(naiveFraction, Double.parseDouble(lines[2].split(",")[6]), 1e-4);
+  }
+
+  @Test
+  public void testContactRateNotInOutput() {
+    Host h = new Host();
+    h.addToHistory(new GeometricPhenotype(1.0, 2.0));
+    String out = capture(List.of(h), 5.0, 0.0, true);
+    assertFalse("contactRate must not appear in CSV output", out.contains("contactRate"));
+  }
+
+  @Test
+  public void testMultipleHostsCorrectHostIds() {
+    Host h0 = new Host();
+    Host h1 = new Host();
+    Host h2 = new Host();
+    h0.addToHistory(new GeometricPhenotype(0.0, 0.0));
+    h1.addToHistory(new GeometricPhenotype(1.0, 1.0));
+    h2.addToHistory(new GeometricPhenotype(2.0, 2.0));
+    List<Host> hosts = Arrays.asList(h0, h1, h2);
+    String out = capture(hosts, 5.0, 0.0, false);
+    String[] lines = out.trim().split("\\r?\\n");
+    assertEquals(3, lines.length);
+    assertEquals("0", lines[0].split(",")[2]);
+    assertEquals("1", lines[1].split(",")[2]);
+    assertEquals("2", lines[2].split(",")[2]);
+  }
+}


### PR DESCRIPTION
Closes #53

## Summary
- Replaced `printHostImmuneHistories` in `HostPopulation` with `printHostImmuneHistoriesCsv`, which emits one row per `(host, infection)` pair in the format `year,deme,host_id,infection_index,ag1,ag2,naive_fraction`
- Naive hosts produce no rows but their `host_id` slot is still consumed so indices are stable within a snapshot/deme block
- `naive_fraction` is denormalized onto every row for tidy-data compatibility
- `contactRate` removed from output (unused downstream)
- CSV header written once on first call, consistent with `out.histories.csv`
- `Simulation.writeImmunityOutputs` tracks `rawHeaderNeeded` locally so the header is emitted exactly once across all demes per snapshot

## Assumptions & Decisions
- `host_id` is sequential within each `(snapshot, deme)` block and resets across calls; this matches the issue spec ("sequential integer within each snapshot/deme block — not persistent across snapshots")
- Both the `List<Host>` overload and the `int n` convenience overload of the old method are removed; `Simulation` already samples before calling, so the int-arg overload was unused